### PR TITLE
docs+ci: sync CHANGELOG and version from GitHub releases

### DIFF
--- a/.github/workflows/changelog-on-release.yml
+++ b/.github/workflows/changelog-on-release.yml
@@ -1,0 +1,96 @@
+name: Changelog on Release
+
+# Prepends a new CHANGELOG.md entry built from the release body, and keeps
+# CMakeLists.txt's project(VERSION ...) + IRON_VERSION_FULL in sync with the
+# release tag. If CMake was stale at the tagged commit — meaning the binaries
+# already uploaded to the release have the wrong `iron --version` output —
+# this workflow re-dispatches release.yml against the updated main so fresh
+# binaries are built and uploaded to the same release.
+#
+# The transformation rule that builds the entry from the release body lives
+# in scripts/update_changelog_from_release.py. That script is also how the
+# initial CHANGELOG.md was populated (PR #16), and it is idempotent: re-runs
+# on an already-synced release are a no-op (exit code 2).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to sync (e.g. v1.0.0-alpha)'
+        required: true
+
+concurrency:
+  group: changelog-on-release-${{ github.event.release.tag_name || github.event.inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # push to main
+  actions: write    # dispatch release.yml when CMake drift is detected
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release tag
+        id: tag
+        run: |
+          TAG="${{ github.event.release.tag_name || github.event.inputs.tag }}"
+          if [ -z "$TAG" ]; then
+            echo "error: no release tag in event payload"
+            exit 1
+          fi
+          echo "value=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag: $TAG"
+
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          # Use a PAT or keep default GITHUB_TOKEN; default token can push to
+          # protected branches only if branch protection allows it.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync CHANGELOG and CMakeLists
+        id: sync
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Script exits 0 on change, 2 on no-op, 1 on error. Accept both
+          # 0 and 2 as success, fail on anything else.
+          python3 scripts/update_changelog_from_release.py \
+            --tag "${{ steps.tag.outputs.value }}" \
+            --repo "${{ github.repository }}" \
+            || rc=$?
+          rc=${rc:-0}
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
+            echo "sync script failed with exit $rc"
+            exit "$rc"
+          fi
+
+      - name: Commit and push
+        if: steps.sync.outputs.any_changed == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md CMakeLists.txt
+          git commit -m "docs: sync CHANGELOG and version for ${{ steps.tag.outputs.value }}"
+          git push origin HEAD:main
+
+      - name: Re-trigger release build (CMake was stale)
+        if: steps.sync.outputs.cmake_changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "CMakeLists.txt was out of sync with ${{ steps.tag.outputs.value }} — re-dispatching release.yml so the release binaries are rebuilt with the correct version string."
+          gh workflow run release.yml \
+            --ref main \
+            -f tag="${{ steps.tag.outputs.value }}"
+
+      - name: No-op summary
+        if: steps.sync.outputs.any_changed != 'true'
+        run: echo "Everything already in sync for ${{ steps.tag.outputs.value }}. No commit, no rebuild."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,175 +1,401 @@
 # Changelog
 
-## v1.0.0-alpha (2026-04-09)
+All notable changes to Iron are published as [GitHub releases](https://github.com/victorl2/iron-lang/releases).
+This file is generated from those release notes automatically on each publish.
 
-### Static Interface Dispatch
-- `impl` keyword replaces `implements` (no backward compatibility)
-- Whole-program interface implementor registry with canonical tag assignment
+## v1.0.0-alpha — Static Interface Dispatch, Layout Optimizations & Compiler Hardening (2026-04-09)
+
+### Summary
+
+Implements the full static interface dispatch spec end-to-end, plus collection methods, layout optimizations, loop fusion, value range compression, arena allocation, and a compiler hardening pass. The compiler resolves all interface method calls at compile time using tagged unions — no vtables, no function pointers, no heap indirection — and applies a composable stack of data-oriented optimizations to polymorphic code.
+
+This PR delivers three milestones in sequence: the original static dispatch work (v0.1-alpha), the optimization stack (v0.1.1-alpha), and a hardening pass that refactored the emitter, strengthened analysis passes, and expanded test coverage (v0.1.2-alpha).
+
+**293 integration tests** pass across 110 commits.
+
+---
+
+### v0.1-alpha — Static Interface Dispatch (Phases 40-45)
+
+**Syntax:**
+- `impl` keyword replaces `implements` (hard switch, no backward compat)
+- `object Dog impl Animal { ... }` declares interface conformance
+
+**Core Dispatch:**
+- Whole-program interface implementor registry (`IfaceRegistry`) with canonical alphabetical tag assignment
 - Tagged union generation: tag enum + payload union + outer struct per interface type
-- Dispatch functions per interface method (switch on tag) — no vtables, no function pointers
-- Auto-wrapping of concrete types into tagged unions at assignment, call, and return sites
-- Dead implementor elimination prunes unused types from unions
+- Dispatch functions generated per interface method (switch on tag)
+- Auto-wrapping: concrete types automatically wrapped into tagged unions at assignment, call, and return sites
+- Dead implementor elimination: unused types pruned from unions
+- Vtable infrastructure completely removed
 
-### Collection Splitting
-- `Iron_SplitList_<Iface>` with per-type sub-arrays instead of heterogeneous arrays
-- Per-type loops for cache locality; order index preserves insertion order
+**Collection Splitting:**
+- `Iron_SplitList_<Iface>` with per-type sub-arrays instead of one heterogeneous array
+- Per-type loops over sub-arrays for cache locality
+- Order index for preserving insertion order when iteration must be sequential
 - Prefetch insertion (`__builtin_prefetch`) for split loops
 
-### Closure Captures
-- Mutable `var` capture by reference with cross-boundary visibility
+**Type System:**
+- `types_assignable()` allows concrete→interface assignment when object declares `impl`
+- Interface method return types resolved from interface signatures
+- LIR verifier allows concrete→interface returns
+
+---
+
+### v0.1.1-alpha — Collection Methods, Captures & Layout Optimizations (Phases 46-50)
+
+#### Phase 46: Full Closure Capture
+- Mutable `var` capture by reference — mutations visible across closure boundary
 - Closures returned from functions (heap-allocated environment)
-- Closures as object fields, nested lambdas, recursive lambdas via `var` self-reference
+- Closures as object fields
+- Nested lambdas capturing outer scope variables
+- Recursive lambdas via `var` self-reference
 - Shared mutable captures between sibling closures
 
-### Collection Methods
-- `map`, `filter`, `reduce`, `forEach`, `sum` with method chaining
+#### Phase 47: Collection Methods
+- `arr.map(func(x) -> y)`, `arr.filter(func(x) -> Bool)`, `arr.reduce(init, func(acc, x) -> acc)`, `arr.forEach(func(x))`, `arr.sum()`
+- Method chaining: `arr.map(...).filter(...).sum()`
 - Array extension method syntax: `func [T].method[U](...)` with generic type parameters
-- Cross-type generics: `.map[U](f: func(T) -> U) -> [U]`
 - Methods work on interface-typed split collections via inline per-type dispatch
+- Cross-type generics: `.map[U](f: func(T) -> U) -> [U]`
 
-### Layout Optimizations
-- Dead field elimination from collection storage structs (interprocedural analysis)
-- SoA/AoS automatic per-loop selection via `IRON_SOA_THRESHOLD` (default 50%)
-- Common field factoring across implementors into shared arrays
-- Variant split for large variants (>2x smallest AND >64 bytes) via heap pointer
-- Layout annotations: `[T, layout: soa]`, `[T, layout: aos]`, `[T, unordered]`
+#### Phase 48: Layout Optimizations
+- **Dead field elimination** — fields never accessed through interface operations are excluded from collection storage structs (interprocedural method body analysis)
+- **SoA/AoS selection** — automatic per-loop layout based on field access ratio (configurable `IRON_SOA_THRESHOLD`, default 50%)
+- **Common field factoring** — fields with same name, type, and position across all implementors stored in a single shared array
+- **Variant split** — large variants (>2x smallest AND >64 bytes) stored via heap pointer in tagged unions for non-collection interface variables
+- **Layout annotations** — `[T, layout: soa]`, `[T, layout: aos]`, `[T, unordered]` override automatic selection with compiler warnings on contradiction
 
-### Loop Fusion & Monomorphic Specialization
-- `@fusible` annotation marks stdlib methods as fusion targets
-- Def-use chain detection via LIR pre-scan with escape analysis
-- `arr.map(f).filter(g).reduce(init, h)` compiles to a single loop per concrete type with no intermediate allocation
-- Split-collection fusion (SoA-aware, per-field array access)
-- Monomorphic collection collapse to plain `Iron_List_<Type>` with direct field access
-- Specialization registry prevents duplicate function bodies
-- `--warn-fusion-break` CLI flag
+#### Phase 49: Loop Fusion & Monomorphic Specialization
+- **`@fusible` annotation** — marks stdlib methods as fusion targets (with spec doc at `docs/fusible-annotation-spec.md`)
+- **Def-use chain detection** — LIR pre-scan identifies chains of fusible calls via STORE/LOAD propagation and escape analysis
+- **Fused loop emission** — `arr.map(f).filter(g).reduce(init, h)` compiles to a single loop per concrete type that applies map, filter, and reduce in one pass with no intermediate allocation
+- **Split collection fusion** — per-type fused loops preserve cache locality; SoA-aware (accesses per-field arrays directly)
+- **Monomorphic collection collapse** — collections proven to hold one concrete type collapse to plain `Iron_List_<Type>` with direct field access
+- **Specialization registry** — stb_ds hash map `(function_name, concrete_type) -> emitted_name` prevents duplicate function bodies
+- **`--warn-fusion-break`** CLI flag for opt-in diagnostics when chains are broken by non-fusible calls
 
-### Value Range Compression
-- New `value_range.c` dataflow module tracking ranges through literals, arithmetic, conditionals, and PHI nodes
-- Type ladder narrowing: int64 → int32 → int16 → int8/uint8 based on proven field ranges
-- Widening reads and narrowing writes preserve program semantics
-- `--report-compression` CLI flag
+#### Phase 50: Value Range Compression & Arena Allocation
+- **Value range analysis** — new `value_range.c` module with conservative dataflow: tracks ranges through literals, arithmetic (overflow-safe), conditionals, and PHI nodes
+- **Type ladder narrowing** — fields proven to fit in narrower types (e.g., `Int` with range `[0, 255]`) stored as `uint8_t` in collection storage structs; full ladder: int64 → int32 → int16 → int8/uint8
+- **Widening reads, narrowing writes** — casts inserted at access sites so program semantics are preserved
+- **Arena pointer registry** — `Iron_Arena` extended with `tracked_ptrs` and `iron_arena_realloc_tracked()` for growable sub-arrays with bulk free
+- **1.5x geometric growth** — per-type sub-arrays start at capacity 8, grow by 1.5x on overflow
+- **Single `_iron_sl_free_all` call** replaces per-array frees in generated code
+- **`--report-compression`** CLI flag for opt-in diagnostic when fields are narrowed
 
-### Arena Allocation
-- `Iron_Arena` extended with `tracked_ptrs` and `iron_arena_realloc_tracked()`
-- 1.5x geometric growth for per-type sub-arrays (start cap 8)
-- Single `_iron_sl_free_all` call replaces per-array frees in generated code
+---
 
-### Analysis Improvements
-- Interprocedural monomorphic detection across function returns and parameters
-- Heuristic-gated specialization for small functions (≤50 LIR instructions, 1–2 call sites)
-- Call-site return range propagation through CALL instructions
-- Conditional branch narrowing: `if x < 100` narrows ranges in true/false branches, AND chains accumulate
-- One-level unrolling for recursive functions
+### Phase 51 — Memory Investigation (Resolved)
 
-### Emitter Refactoring
-- `emit_c.c` (~7120 lines) decomposed into 5 focused modules: `emit_c.c`, `emit_helpers.c`, `emit_structs.c`, `emit_split.c`, `emit_fusion.c`
-- Zero behavioral changes
+Investigation triggered by 50GB+ RSS shown in Activity Monitor. **Root cause:** Debug builds unconditionally enabled `-fsanitize=address,undefined`, and AddressSanitizer reserves ~20TB of virtual address space on macOS by design. Actual physical memory (RSS) was ~50MB.
 
-### Build
-- Sanitizers moved behind `IRON_ENABLE_SANITIZERS` CMake option (default OFF), fixing 20TB virtual address reservation from unconditional ASan on debug builds
-- `stb_ds` hash map leaks at end of `iron_lir_emit_c` freed
+**Fix:** Sanitizers moved behind `IRON_ENABLE_SANITIZERS` CMake option (default OFF). Also freed a few `stb_ds` hash maps that leaked at the end of `iron_lir_emit_c`.
 
-### Test Suite
-- 293 integration tests (up from ~230)
-- 11 LIR unit tests, 5 HIR unit tests, 44/44 CTest targets pass
-- Edge cases (empty, single element, single implementor, zero-field), stress (10K+ elements, 10 implementors, 5–6 op fusion chains), and composition tests (SoA+fusion, dead field+compression, arena+SoA+dead field)
-- Generated C verification via pattern grep (`uint8_t`, `_iron_sl_realloc_tracked`, per-field array names)
-- Benchmark speed thresholds raised 1.5x → 2.5x across 113 per-problem configs
+---
 
-## v0.0.8-alpha (2026-04-06)
+### v0.1.2-alpha — Compiler Hardening & Refactoring (Phases 52-54)
 
-### Algebraic Data Types
-- Enum variants with typed payloads (`enum Shape { Circle(Float), Rect(Float, Float) }`)
-- Exhaustive pattern matching with `->` arrow syntax and destructuring
-- Generic enums with monomorphization (`Option[T]`, `Result[T, E]`)
-- Recursive variant auto-boxing (`enum Expr { BinOp(Expr, Op, Expr) }`)
-- Methods on enums with `match self` dispatch
+#### Phase 52: Emitter Refactoring
+Decomposed the monolithic `emit_c.c` (~7120 lines) into 5 focused modules, zero behavioral changes:
 
-### Lambda Capture
-- Complete closure capture system with typed environment structs
-- `val` captured by value, `var` captured by reference
-- Capture support across spawn/parallel-for concurrency primitives
-- Verbose capture analysis via `--verbose` flag
+| File | Lines | Responsibility |
+|------|------:|----------------|
+| `emit_c.c` | 5520 | Core orchestration, `iron_lir_emit_c`, `emit_func_body`, `emit_instr`, pre-scan passes |
+| `emit_helpers.c` | 408 | `EmitCtx` struct, shared utilities, `emit_ctx_cleanup()` |
+| `emit_structs.c` | 527 | Topo sort, object struct bodies, tagged unions, `emit_type_decls` |
+| `emit_split.c` | 622 | Split collection emission (push, free, iteration, arena helpers) |
+| `emit_fusion.c` | 398 | Fused loop emission, `emit_fused_chain` |
 
-### Stdlib Expansion
-- 19 String built-in methods (upper, lower, trim, split, replace, index_of, char_at, to_int, repeat, pad_left, etc.)
-- Math: asin, acos, atan2, sign, seed, random_float, log, log2, exp, hypot
-- IO: read_line, append_file, basename, dirname, join_path, extension, is_dir, read_lines
-- Time: Timer with accumulator API (update, done, reset)
-- Log: set_level, level constants
+#### Phase 53: Analysis Improvements
+- **Interprocedural monomorphic detection** — tracks concrete types across function return values and parameters. Helper functions returning single-type collections trigger collapse at call sites.
+- **Heuristic-gated specialization** — small functions (≤50 LIR instructions) with 1-2 call sites and dispatch overhead get specialized copies; larger functions use conservative union of call-site types
+- **Call-site return range propagation** — `value_range.c` now tracks function return ranges through CALL instructions instead of conservative TOP
+- **Conditional branch narrowing** — `if x < 100` narrows x's range to `[min, 99]` in the true branch and `[100, max]` in the false branch; AND chains accumulate narrowings across dominated blocks
+- **One-level unrolling for recursion** — recursive functions analyzed via base case only
 
-### Semantic Analysis
-- Match exhaustiveness checking for both payload and plain enums
-- Definite assignment analysis (use-before-init detection)
-- Cast safety validation with narrowing warnings and overflow errors
-- Array/slice bounds checking at compile time
-- Concurrency safety: mutation detection in parallel/spawn blocks
-- Generic constraint enforcement at instantiation sites
-- LIR verifier hardening (PHI type consistency, call argument validation)
-- 15 new diagnostic codes, ~100 new unit tests
+#### Phase 54: Test Hardening
+- **5 edge case tests** — empty collections, all-filtered-out, single element, single implementor, zero-field structs
+- **3 stress tests** — 10K+ element collections with arena growth (loop + push), 10 implementors, 5-6 operation fusion chains
+- **5 composition tests** — SoA+fusion, dead field+compression, monomorphic+computation, arena+SoA+dead field triple, mega test combining all optimizations
+- **Benchmark thresholds raised** — speed 1.5x → 2.5x across 113 per-problem configs to tolerate CI runner variance
+- **Generated C verification** — tests grep compiled C output for expected patterns (`uint8_t` for compression, `_iron_sl_realloc_tracked` for arena, per-field array names for SoA, absence of `Iron_SplitList_` for monomorphic collapse)
+
+---
+
+### What the compiler generates
+
+**Iron source:**
+```
+interface Shape { func area() -> Int }
+object Circle impl Shape { var radius: Int; var debug_name: String }
+object Square impl Shape { var side: Int; var debug_name: String }
+
+func Circle.area() -> Int { return self.radius * self.radius * 3 }
+func Square.area() -> Int { return self.side * self.side }
+
+val shapes: [Shape] = [Circle(5), Square(3), Circle(10)]
+val total = shapes.map(func(s) -> Int { return s.area() })
+                  .filter(func(a) -> Bool { return a > 10 })
+                  .sum()
+println("{total}")
+```
+
+**Generated C (simplified):**
+```c
+// Dead field elimination: debug_name removed from collection storage
+typedef struct { uint8_t radius; } Iron_Circle_Stor;  // VRC: radius compressed
+typedef struct { uint8_t side; } Iron_Square_Stor;
+
+// Split collection with arena-tracked sub-arrays
+typedef struct {
+    Iron_Circle_Stor *circles; size_t circles_count; size_t circles_cap;
+    Iron_Square_Stor *squares; size_t squares_count; size_t squares_cap;
+    void **_tracked; size_t _tracked_count;
+} Iron_SplitList_Shape;
+
+// Fused loop: map + filter + sum in one pass, per concrete type, no intermediate arrays
+int64_t total = 0;
+for (size_t i = 0; i < shapes.circles_count; i++) {
+    int64_t a = (int64_t)shapes.circles[i].radius *
+                (int64_t)shapes.circles[i].radius * 3;
+    if (a > 10) total += a;
+}
+for (size_t i = 0; i < shapes.squares_count; i++) {
+    int64_t a = (int64_t)shapes.squares[i].side *
+                (int64_t)shapes.squares[i].side;
+    if (a > 10) total += a;
+}
+```
+
+**Optimizations composed in the fused output above:** static dispatch (no vtable), collection splitting (per-type loops), dead field elimination (no `debug_name`), value range compression (`uint8_t radius`), arena allocation (tracked realloc), loop fusion (single pass per type), and widening casts at access sites.
+
+---
+
+### Test plan
+
+- [x] **293 integration tests** pass (up from ~230 at start of PR)
+- [x] All LIR unit tests pass (11 tests)
+- [x] All HIR unit tests pass (5 tests)
+- [x] Full test suite: 44 tests, 0 failures
+- [x] Static dispatch: `static_dispatch_basic`, `static_dispatch_func_param`, `static_dispatch_multi_method`, `static_dispatch_return`
+- [x] Split collections: `split_collection_basic`, `split_collection_multi_method`, `split_collection_param`
+- [x] Captures: 6 capture tests (mutate, return_closure, lambda_capture_lambda, shared_mutable, closure_object_field, recursive_lambda)
+- [x] Layout: `layout_dead_field`, `layout_soa_select`, `layout_common_field`, `layout_variant_split`, `layout_annotation`, `layout_annotation_warn`
+- [x] Fusion: 8 fusion tests (flat and split collections, chain break, intermediate escape)
+- [x] Monomorphic: `mono_single_type_collapse`, `mono_multi_type_no_collapse`, `mono_specialization_registry`, `mono_interprocedural`, `mono_specialization_heuristic`
+- [x] Value range: `value_range_compress`, `value_range_return_prop`, `value_range_conditional`
+- [x] Arena: `arena_split_collection`
+- [x] Edge cases: 5 edge case tests (empty, all-filtered-out, single element, single implementor, zero-field)
+- [x] Stress: 3 stress tests (10K elements, 10 implementors, deep fusion)
+- [x] Composition: 5 composition tests (SoA+fusion, dead field+compress, monomorphic, arena+SoA+dead, mega)
+- [x] Benchmark thresholds validated across 113 benchmark configs
+
+### Known limitations discovered during hardening
+
+These are pre-existing compiler bugs exposed by the hardening phase test suite. They're documented in test workarounds and should be addressed in a follow-up:
+
+1. `.push()` on interface-typed arrays not supported at language level (typed array push works)
+2. Monomorphic collapse interacts badly with the `.map()` chain method path
+3. SoA layout + fusion has a `Stor` type name mismatch in specific combinations
+4. `binary_tree_diameter` benchmark is borderline on macOS runners (threshold raised to 2.5x as mitigation)
+
+## v0.0.8-alpha — ADTs, Lambda Capture & Semantic Analysis (2026-04-06)
+
+Three major feature branches land in this release: algebraic data types, a complete lambda capture system, and comprehensive semantic analysis hardening.
+
+### Algebraic Data Types (Phases 32–38)
+Full ADT support with enum payloads, pattern matching, generics, and recursive types:
+
+- **Enum variants with payloads** — `enum Shape { Circle(Float), Rect(Float, Float) }`
+- **Exhaustive pattern matching** — arrow syntax (`->`) with destructuring, wildcards, nested patterns, and else arms
+- **Methods on enums** — `func Shape.area()` with `match self` dispatch
+- **Generic enums** — `Option[T]`, `Result[T, E]` with monomorphization and type-argument-aware C name mangling
+- **Recursive variant auto-boxing** — `enum Expr { IntLit(Int), BinOp(Expr, Op, Expr) }` with automatic malloc/free
+- 18 ADT integration tests covering all patterns
+
+### Lambda Capture System (Phases 32–36)
+Complete closure capture with typed environments:
+
+- **Free variable analysis** — new `capture.c` pass identifies outer-scope references in lambda bodies
+- **`Iron_Closure {fn, env}` fat pointer** — replaces bare `void*` for all closure values
+- **Typed environment structs** — named fields (`e->count`, not `e->_cap0`), val capture by value, var capture by reference
+- **Uniform `void* _env` calling convention** for all lifted lambdas
+- **Spawn/parallel-for capture wiring** — environment structs forwarded through concurrency primitives
+- **Closure call overhead benchmark** — negligible overhead confirmed
+- **Verbose capture report** via `--verbose` flag
+- 20 capture integration tests covering all canonical patterns
+
+### Stdlib Expansion (Phases 37–39)
+- **19 String built-in methods** — upper, lower, trim, contains, split, replace, starts_with, ends_with, etc.
+- **Math module** — asin, acos, atan2, sign, seed, random_float, log, log2, exp, hypot
+- **IO module** — read_bytes, write_bytes, read_line, append_file, basename, dirname, join_path, extension, is_dir, read_lines
+- **Time module** — Timer with accumulator API (update, done, reset)
+- **Log module** — set_level, level constants
+- Compiler dispatch fixes for String/collection/Timer method calls
+
+### Semantic Analysis Hardening (Phases 32–39)
+Closes all 12 documented semantic analysis gaps with 15 new diagnostic codes and ~100 new unit tests:
+
+- **Match exhaustiveness** — non-exhaustive match on enum types lists uncovered variants; duplicate arms detected
+- **PHI type consistency** — LIR verifier catches mismatched incoming types
+- **Call argument validation** — LIR verifier validates argument types and count against callee signatures
+- **Generic constraints** — concrete type arguments violating declared constraints rejected at instantiation
+- **Cast safety** — source type validation, Int-to-Bool rejection, narrowing warnings, literal overflow errors
+- **Definite assignment** — new dataflow analysis pass detects variables read before initialization
+- **Array/slice bounds** — constant indices checked against known array sizes
+- **Escape analysis extensions** — heap values tracked through field/array/function argument assignments
+- **String interpolation** — non-stringifiable types produce warnings
+- **Compound overflow** — narrow integer overflow detection
+- **Concurrency safety** — field/array mutation detection in parallel/spawn blocks, spawn capture analysis, read-write race detection
 
 ### Test Suite
 - 236 integration tests (up from 138)
 - 76 type checker unit tests
-- 44/44 CTest targets pass
+- 44/44 CTest targets pass, 0 regressions
 
-## v0.0.1-alpha (2026-03-26)
+## v0.0.7-alpha — IR Optimizations & HIR Pipeline (2026-04-02)
 
-First public alpha release of the Iron programming language.
+### IR Optimization Passes (Phases 15–17)
+The compiler now includes a multi-pass IR optimization pipeline, closing the performance gap with hand-written C:
 
-### Language Features
+- **Copy propagation, DCE & constant folding** — eliminates redundant temporaries, dead stores, and compile-time-known expressions
+- **Expression inlining** — use-count and purity analysis inlines single-use subexpressions directly into consumers, reducing register pressure
+- **Store/load elimination** — escape analysis identifies local-only memory and removes redundant store/load pairs
+- **Strength reduction** — dominator tree + loop analysis replaces expensive induction-variable multiplications with additions inside loops
 
-- **Type system**: `Int`, `Float`, `Bool`, `String`, nullable types (`T?`), type inference
-- **Objects**: struct-like objects with `val`/`var` fields, methods via `func Type.method()`
-- **Inheritance**: `extends` for single inheritance, `implements` for interfaces
-- **Enums**: with explicit ordinal values
-- **Generics**: with monomorphization (zero-cost abstractions)
-- **Pattern matching**: `match` expressions with exhaustiveness checking
-- **Lambdas**: `func(x: Int) -> Int { x * 2 }`
-- **Null safety**: non-nullable by default, compiler-enforced narrowing after null checks
+### HIR Foundation (Phases 19–20)
+A new High-level IR layer sits between the AST and the existing LIR, enabling future high-level optimizations:
 
-### Memory Management
+- **HIR data structures** — typed IR nodes, builder API, constructors, and CMake wiring
+- **HIR printer & verifier** — human-readable dump and structural invariant checks
+- **AST-to-HIR lowering** — full translation from AST to the new HIR representation
+- **HIR-to-LIR three-pass lowering** — declaration collection, body lowering, and fixup
+- **Full pipeline wiring** — AST → HIR → LIR → C is now the default compilation path
+- **Behavioral parity achieved** — old AST-to-LIR files deleted; single pipeline established
+- **LIR rename** — `IronIR_` namespace renamed to `IronLIR_` for clarity
 
-- Stack allocation by default
-- `heap` keyword for explicit heap allocation with auto-free
-- `rc` for reference-counted shared ownership (atomic)
-- `defer` for deterministic cleanup
-- `leak` for intentional permanent allocations
-- Escape analysis to optimize heap allocations
+### Test Suite Expansion
+- 57 AST-to-HIR unit tests
+- 28 HIR-to-LIR feature-matrix tests
+- 110 HIR integration tests (8 categories + edge cases)
+- IR optimization unit + integration tests for each pass
+- 10 concurrency correctness benchmarks
 
-### Concurrency
+### Benchmark Infrastructure (Phase 18)
+- `--json` output and `--compare` mode for the benchmark runner
+- Threshold tuning for 137/137 benchmark pass rate
+- Concurrency correctness benchmarks (race detection, lock ordering, atomic patterns)
 
-- `pool("name", n)` thread pools
-- `spawn` / `await` for background tasks
-- `channel[T](cap)` for message passing
-- `parallel` for loops with work stealing
+### CI Improvements
+- Multi-OS matrix strategy (macOS + Ubuntu)
+- Migrated to modern GitHub Actions runners
+- PR dry-run and branch protection for releases
 
-### Standard Library
+### Bug Fixes
+- Fixed DCE and use_counts for `ARRAY_LIT` with >64 elements
+- Fixed `ARRAY_LIT` inlining exclusion and int32 emission-time narrowing
+- Fixed LIR body generation for empty-body non-void stub functions
 
-- **Built-in**: `print`, `println`, `len`, `range`, `min`, `max`, `clamp`, `abs`, `assert`
-- **Collections**: `List[T]`, `Map[K,V]`, `Set[T]`
-- **math**: trig, sqrt, pow, lerp, random
-- **io**: file read/write
-- **time**: timestamps, timers, sleep
-- **log**: leveled logging (info, warn, error, debug)
+## v0.0.4-alpha — Performance Codegen & Benchmark Suite (2026-03-28)
 
-### Compiler
+### Performance Optimizations
+Iron now generates C code that achieves **≤1.2x parity with hand-written C** across 93% of 127 benchmark problems. Key optimizations:
 
-- Full pipeline: lexer, parser, semantic analysis, C code generation
-- Rust-style error diagnostics with source snippets and color
-- Compile-time evaluation (`comptime`)
-- `iron build` / `run` / `check` / `fmt` / `test` CLI commands
-- Compiles to C, then to native binary via clang/gcc
-- `-O3` optimization for release builds
+- **Stack arrays**: `fill(n, val)` and array literals emit stack-allocated C arrays instead of heap `Iron_List_T`
+- **Direct indexing**: `arr[i]` compiles to `items[idx]` bypassing function-call accessors
+- **Transitive pointer-mode parameters**: Arrays passed through chains of function calls (including recursive) use `T*` pointers instead of struct copies
+- **Scope-based free**: Non-escaping heap arrays are freed at function exit
+- **Range hoisting**: Loop bounds computed once in pre-header, not every iteration
+- **Inline `Iron_range()`**: Removes cross-TU optimization barrier, enabling clang to constant-fold entire benchmark loops
 
-### Graphics & FFI
+### Benchmark Suite (127 problems)
+- **107 sequential** problems: Array/Two-Pointer, Dynamic Programming, Graph/Tree/Search, String/Stack/Queue, Advanced Algorithms, LeetCode classics, Language Features
+- **20 parallel/concurrent** problems: parallel-for workloads (matrix multiply, Mandelbrot, N-body, ray tracing, prime sieve, fibonacci, Monte Carlo pi) and spawn tasks
+- Harness compares runtime speed and peak memory against equivalent C solutions
+- CI integration with regression detection
 
-- Raylib bindings (`raylib.iron`)
-- `draw {}` blocks for render passes
-- C FFI via `extern func` declarations
+### Bug Fixes
+- VLA goto bypass: `alloca()` instead of C99 VLA avoids clang errors with goto-based control flow
+- Array reassignment detection: stack eligibility revoked when variable is reassigned from function call return
+- Deterministic PRNG in parallel benchmarks (no signed integer overflow)
 
-### Platforms
+### What's Next (v0.0.5-alpha)
+[IR Optimization Spec](docs/v005-ir-optimization-spec.md) — Copy propagation, expression inlining, dead code elimination, and strength reduction passes to close the remaining 7% performance gap.
 
-- macOS (arm64, x86_64)
-- Linux (x86_64)
-- Windows (experimental)
+## v0.0.3-alpha Package Manager (2026-03-28)
+
+Iron now ships a two-binary toolchain: `ironc` (compiler) and `iron` (package manager). Projects use `iron.toml` to declare metadata and GitHub-sourced dependencies, which are automatically fetched, cached, and pinned in a reproducible lockfile.
+
+#### Key accomplishments
+
+**Project Workflow (`iron` CLI)**
+- `iron init` / `iron init --lib` scaffolds new projects with `iron.toml` and `src/`
+- `iron build`, `iron run`, `iron check`, `iron test` — Cargo-style commands with colored output
+- TOML parser for `[package]` and `[dependencies]` with inline-table support
+
+**Dependency Resolution**
+- GitHub REST API tag-to-SHA resolution (annotated + lightweight tags, `v0.1.0` / `0.1.0` fallback)
+- Tarball download and extraction into `~/.iron/cache/`
+- DFS graph traversal with cycle detection, diamond dedup, and version conflict errors
+- Source concatenation: deps (topological order) + project → `target/combined.iron` → `ironc`
+
+**Lockfile (`iron.lock`)**
+- `lock_version = 1` with `[[package]]` entries (name, version, git, sha)
+- All deps flattened (direct + transitive), sorted alphabetically
+- Auto-resolve new deps, auto-prune removed deps, locked builds use exact SHAs
+- `IRON_GITHUB_TOKEN` / `GITHUB_TOKEN` support for authenticated API requests (5000/hr)
+
+**Infrastructure**
+- Two-target CMake build: `ironc` (compiler) and `iron` (package manager)
+- `ironc --output` flag for controlled binary placement
+- 38 tests passing (including new regression and integration tests)
+
+## v0.0.2-alpha High IR (2026-03-27)
+
+Introduced SSA-form intermediate representation between AST and C emission, replacing direct AST-to-C codegen with a decoupled AST->IR->C pipeline.
+
+#### Key accomplishments
+- SSA-form IR data structures with 42 instruction kinds, printer, and verifier
+- Full AST-to-IR lowering for all Iron language features
+- IR-to-C emission backend fully replacing old codegen
+- Comprehensive test suite: 46 IR tests, 13 algorithms, 12 edge cases, 3 composites
+- Release pipeline: GitHub Actions CI for 4 platforms, install.sh, iron --version
+
+## Iron v0.0.1-alpha (2026-03-27)
+
+First public alpha release of the Iron programming language — a compiled, performant language built for game development.
+
+### Highlights
+
+- **Full compiler pipeline**: lexer, parser, semantic analysis, C code generation
+- **Strong type system**: generics, nullable types, type inference, interfaces
+- **Memory control**: stack/heap/rc/defer — no GC, no borrow checker
+- **Concurrency**: thread pools, spawn/await, channels, parallel for loops
+- **Standard library**: collections, math, file I/O, time, logging
+- **Game dev ready**: Raylib bindings, `draw {}` blocks, C FFI
+- **Cross-platform**: macOS, Linux, Windows (experimental)
+
+### Install from source
+
+```bash
+git clone https://github.com/victorl2/iron-lang.git
+cd iron-lang
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+./build/iron run examples/hello.iron
+```
+
+See [INSTALL.md](https://github.com/victorl2/iron-lang/blob/main/INSTALL.md) for platform-specific instructions.
+
+### What's included
+
+- `iron build <file>` — compile to native binary
+- `iron run <file>` — compile and execute
+- `iron check <file>` — type-check without compiling
+- `iron fmt <file>` — format source code
+- `iron test` — discover and run tests
+
+See the full [CHANGELOG](https://github.com/victorl2/iron-lang/blob/main/CHANGELOG.md) for details.
+
+> **Alpha software** — expect breaking changes between releases.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,12 @@
 cmake_minimum_required(VERSION 3.25)
-project(iron VERSION 0.0.5 LANGUAGES C)
+project(iron VERSION 1.0.0 LANGUAGES C)
+
+# Full release version, including any pre-release suffix (e.g. "1.0.0-alpha").
+# CMake's project(VERSION ...) only accepts numeric MAJOR.MINOR.PATCH[.TWEAK],
+# so the suffixed form lives in its own variable and is baked into the binaries
+# as IRON_VERSION_STRING below. Both this line and the project() line above are
+# kept in sync with the latest GitHub release by .github/workflows/changelog-on-release.yml.
+set(IRON_VERSION_FULL "1.0.0-alpha")
 
 # ── Version info baked at compile time ─────────────────────────────────────
 execute_process(
@@ -141,7 +148,7 @@ endif()
 # Inject the absolute path to src/ so the CLI can find runtime sources at build time
 target_compile_definitions(ironc PRIVATE
     IRON_SOURCE_DIR="${CMAKE_SOURCE_DIR}/src"
-    IRON_VERSION_STRING="${PROJECT_VERSION}"
+    IRON_VERSION_STRING="${IRON_VERSION_FULL}"
     IRON_GIT_HASH="${IRON_GIT_HASH}"
     IRON_BUILD_DATE="${IRON_BUILD_DATE}"
     IRON_BINARY_NAME="ironc"
@@ -161,7 +168,7 @@ add_executable(iron
 )
 target_include_directories(iron PRIVATE src)
 target_compile_definitions(iron PRIVATE
-    IRON_VERSION_STRING="${PROJECT_VERSION}"
+    IRON_VERSION_STRING="${IRON_VERSION_FULL}"
     IRON_GIT_HASH="${IRON_GIT_HASH}"
     IRON_BUILD_DATE="${IRON_BUILD_DATE}"
 )

--- a/scripts/update_changelog_from_release.py
+++ b/scripts/update_changelog_from_release.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Sync CHANGELOG.md and CMakeLists.txt with a GitHub release.
+
+Invoked by .github/workflows/changelog-on-release.yml on every
+`release: published` event, and usable locally for manual re-syncs.
+
+Given a release tag (e.g. v1.0.0-alpha):
+
+  1. Fetch the release name, body, and publish date via `gh release view`.
+  2. If CHANGELOG.md does not already contain a `## <name> (<date>)`
+     entry for this tag, prepend one using the same formatting rule
+     that built the initial CHANGELOG (see docstring of `build_entry`).
+  3. If CMakeLists.txt's `project(iron VERSION X.Y.Z ...)` or
+     `set(IRON_VERSION_FULL "X.Y.Z[-suffix]")` do not match the tag,
+     rewrite them in place.
+
+Exit codes:
+  0  something changed on disk (caller should commit+push)
+  2  everything already up to date, no changes made
+  1  usage or fetch error
+
+Usage:
+  scripts/update_changelog_from_release.py --tag v1.0.0-alpha
+  scripts/update_changelog_from_release.py --tag v1.0.0-alpha --repo victorl2/iron-lang
+  scripts/update_changelog_from_release.py --tag v1.0.0-alpha --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG_PATH = REPO_ROOT / "CHANGELOG.md"
+CMAKE_PATH = REPO_ROOT / "CMakeLists.txt"
+
+TAG_RE = re.compile(r"^v?(\d+\.\d+\.\d+)(-[A-Za-z0-9.+-]+)?$")
+
+# Matches: project(iron VERSION X.Y.Z[.W] LANGUAGES C)
+CMAKE_PROJECT_RE = re.compile(
+    r"^(project\(\s*iron\s+VERSION\s+)(\d+\.\d+\.\d+(?:\.\d+)?)(\b[^)]*\))",
+    re.MULTILINE,
+)
+# Matches: set(IRON_VERSION_FULL "X.Y.Z-anything")
+CMAKE_FULL_RE = re.compile(
+    r'^(set\(\s*IRON_VERSION_FULL\s+")([^"]*)("\s*\))',
+    re.MULTILINE,
+)
+
+
+def parse_tag(tag: str) -> tuple[str, str]:
+    """Split a release tag into (cmake_numeric, display_full).
+
+    >>> parse_tag("v1.0.0-alpha")
+    ('1.0.0', '1.0.0-alpha')
+    >>> parse_tag("v0.0.8-alpha")
+    ('0.0.8', '0.0.8-alpha')
+    >>> parse_tag("1.2.3")
+    ('1.2.3', '1.2.3')
+    """
+    m = TAG_RE.match(tag.strip())
+    if not m:
+        raise SystemExit(f"error: tag {tag!r} does not match vMAJOR.MINOR.PATCH[-suffix]")
+    numeric = m.group(1)
+    suffix = m.group(2) or ""
+    return numeric, numeric + suffix
+
+
+def fetch_release(tag: str, repo: str | None) -> dict:
+    cmd = ["gh", "release", "view", tag, "--json", "name,tagName,publishedAt,body"]
+    if repo:
+        cmd.extend(["--repo", repo])
+    try:
+        out = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except FileNotFoundError:
+        raise SystemExit("error: gh CLI not found on PATH")
+    except subprocess.CalledProcessError as e:
+        raise SystemExit(f"error: gh release view {tag} failed:\n{e.stderr}")
+    return json.loads(out.stdout)
+
+
+# ── CHANGELOG entry builder ──────────────────────────────────────────────
+# Must stay in lock-step with the bulk builder used to rewrite CHANGELOG.md
+# initially (see PR #16). Any change to the formatting rule here MUST be
+# mirrored in the bulk builder, otherwise re-syncing the whole file would
+# produce a diff.
+#
+# Rule:
+#   * Version header: "## <release.name> (<YYYY-MM-DD>)"
+#   * If the body's first non-blank line is a "## " heading containing
+#     the release tag, drop it and leave remaining headings at their
+#     original depth (the stripped line implicitly played the role of
+#     the version header, so descendants are already correctly nested).
+#   * Otherwise, demote every markdown heading by one level so body
+#     content ("##", "###", ...) nests cleanly under the prepended "##".
+
+
+def normalize_body(body: str) -> str:
+    body = body.replace("\r\n", "\n").replace("\r", "\n")
+    body = "\n".join(line.rstrip() for line in body.split("\n"))
+    body = re.sub(r"\n{3,}", "\n\n", body)
+    return body.strip()
+
+
+def strip_redundant_tag_heading(body: str, tag: str) -> tuple[str, bool]:
+    lines = body.split("\n")
+    idx = 0
+    while idx < len(lines) and lines[idx].strip() == "":
+        idx += 1
+    if idx < len(lines):
+        first = lines[idx]
+        if first.startswith("## ") and tag in first:
+            del lines[idx]
+            if idx < len(lines) and lines[idx].strip() == "":
+                del lines[idx]
+            return "\n".join(lines), True
+    return body, False
+
+
+def demote_headings(body: str) -> str:
+    return re.sub(r"^(#+)", r"#\1", body, flags=re.MULTILINE)
+
+
+def build_entry(release: dict) -> str:
+    name = release["name"].strip()
+    tag = release["tagName"].strip()
+    date = release["publishedAt"][:10]
+    body = normalize_body(release["body"])
+    body, stripped = strip_redundant_tag_heading(body, tag)
+    if not stripped:
+        body = demote_headings(body)
+    return f"## {name} ({date})\n\n{body}\n"
+
+
+# ── CHANGELOG.md update ──────────────────────────────────────────────────
+
+def changelog_has_entry_for(text: str, tag: str) -> bool:
+    """True if CHANGELOG.md already has a '## ... <tag> ...' heading."""
+    for line in text.split("\n"):
+        if line.startswith("## ") and tag in line:
+            return True
+    return False
+
+
+def prepend_entry(current: str, entry: str) -> str:
+    """Insert `entry` after the preamble and before the first existing '## '."""
+    lines = current.split("\n")
+    # Find the first line that starts with '## ' (existing release entry).
+    insert_at = None
+    for i, line in enumerate(lines):
+        if line.startswith("## "):
+            insert_at = i
+            break
+    if insert_at is None:
+        # No prior entries — append after the whole preamble.
+        return current.rstrip() + "\n\n" + entry.rstrip() + "\n"
+    before = "\n".join(lines[:insert_at]).rstrip()
+    after = "\n".join(lines[insert_at:])
+    return before + "\n\n" + entry.rstrip() + "\n\n" + after
+
+
+# ── CMakeLists.txt update ───────────────────────────────────────────────
+
+def update_cmake(text: str, numeric: str, display_full: str) -> tuple[str, bool]:
+    """Rewrite project(VERSION) and IRON_VERSION_FULL. Returns (new_text, changed)."""
+    changed = False
+
+    def replace_project(m: re.Match[str]) -> str:
+        nonlocal changed
+        if m.group(2) != numeric:
+            changed = True
+            return m.group(1) + numeric + m.group(3)
+        return m.group(0)
+
+    def replace_full(m: re.Match[str]) -> str:
+        nonlocal changed
+        if m.group(2) != display_full:
+            changed = True
+            return m.group(1) + display_full + m.group(3)
+        return m.group(0)
+
+    if not CMAKE_PROJECT_RE.search(text):
+        raise SystemExit("error: could not find 'project(iron VERSION ...)' in CMakeLists.txt")
+    if not CMAKE_FULL_RE.search(text):
+        raise SystemExit("error: could not find 'set(IRON_VERSION_FULL ...)' in CMakeLists.txt")
+
+    text = CMAKE_PROJECT_RE.sub(replace_project, text, count=1)
+    text = CMAKE_FULL_RE.sub(replace_full, text, count=1)
+    return text, changed
+
+
+# ── Main ────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--tag", required=True, help="Release tag, e.g. v1.0.0-alpha")
+    p.add_argument("--repo", default=None, help="owner/name (default: current repo)")
+    p.add_argument("--dry-run", action="store_true", help="Print diff instead of writing")
+    args = p.parse_args()
+
+    numeric, display_full = parse_tag(args.tag)
+    release = fetch_release(args.tag, args.repo)
+
+    # --- CHANGELOG ---
+    changelog_text = CHANGELOG_PATH.read_text()
+    changelog_changed = False
+    if changelog_has_entry_for(changelog_text, args.tag):
+        print(f"CHANGELOG.md already has entry for {args.tag}, skipping.")
+    else:
+        entry = build_entry(release)
+        new_changelog = prepend_entry(changelog_text, entry)
+        changelog_changed = new_changelog != changelog_text
+        if changelog_changed:
+            if args.dry_run:
+                print(f"--- CHANGELOG.md would gain a new entry for {args.tag} ---")
+            else:
+                CHANGELOG_PATH.write_text(new_changelog)
+                print(f"CHANGELOG.md: prepended entry for {args.tag}")
+
+    # --- CMakeLists.txt ---
+    cmake_text = CMAKE_PATH.read_text()
+    new_cmake, cmake_changed = update_cmake(cmake_text, numeric, display_full)
+    if cmake_changed:
+        if args.dry_run:
+            print(f"--- CMakeLists.txt would update to VERSION {numeric} / FULL {display_full} ---")
+        else:
+            CMAKE_PATH.write_text(new_cmake)
+            print(f"CMakeLists.txt: updated VERSION={numeric} IRON_VERSION_FULL={display_full}")
+    else:
+        print(f"CMakeLists.txt already at VERSION {numeric} / FULL {display_full}, skipping.")
+
+    # Expose change flags to the workflow via $GITHUB_OUTPUT when available,
+    # falling back to stderr for local runs. The workflow reads these to
+    # decide whether to commit and whether to re-trigger the release build
+    # (CMake change → stale binaries → rebuild needed).
+    outputs = {
+        "changelog_changed": "true" if changelog_changed else "false",
+        "cmake_changed": "true" if cmake_changed else "false",
+        "any_changed": "true" if (changelog_changed or cmake_changed) else "false",
+    }
+    gh_output = os.environ.get("GITHUB_OUTPUT")
+    if gh_output:
+        with open(gh_output, "a") as fh:
+            for k, v in outputs.items():
+                fh.write(f"{k}={v}\n")
+    else:
+        for k, v in outputs.items():
+            print(f"[output] {k}={v}", file=sys.stderr)
+
+    return 0 if (changelog_changed or cmake_changed) else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Rewrites `CHANGELOG.md` so it mirrors the canonical source of release information — the [GitHub releases page](https://github.com/victorl2/iron-lang/releases) — for all 7 published releases.
- Adds `.github/workflows/changelog-on-release.yml`, a workflow that runs on every `release: published` event and keeps `CHANGELOG.md` and the version plumbing in `CMakeLists.txt` in lock-step with the release tag automatically.
- Extends `CMakeLists.txt` with an `IRON_VERSION_FULL` variable so `iron --version` can display the full tag including pre-release suffixes (e.g. `1.0.0-alpha`) instead of only CMake's numeric `PROJECT_VERSION` (`1.0.0`).
- Bumps `project(iron VERSION 0.0.5)` → `1.0.0` and `IRON_VERSION_FULL` → `1.0.0-alpha` to match the current release. The workflow would have done this automatically on the next publish; doing it now closes the existing drift.

## The baseline rewrite

Each CHANGELOG entry now has the shape:

```markdown
## <release.name> (<YYYY-MM-DD>)

<release body>
```

Rule applied to the body before insertion:

1. If the first non-blank line of the release body is a `## ` heading containing the release tag (e.g. `## v0.0.8-alpha — ...`), that line is dropped — it would otherwise duplicate the version header above.
2. If step 1 stripped a heading, the remaining content keeps its original heading depths (the stripped `##` already played the role of the version header, so descendants are already one level deeper).
3. Otherwise, every markdown heading in the body is demoted by one level (`##` → `###`, `###` → `####`, …) so body content nests cleanly under the prepended `##`.

The rule is implemented once in `scripts/update_changelog_from_release.py` and used both for the initial bulk rewrite and the per-release incremental update, so the file stays self-similar across runs.

## The workflow

`.github/workflows/changelog-on-release.yml` triggers on:

- `release: published` (the real path — fires on every publish, including pre-releases)
- `workflow_dispatch` with a `tag` input (manual re-sync / backfill)

On each run it invokes the Python script, which:

1. Fetches the release name, body, and publish date via `gh release view`.
2. Checks CHANGELOG.md for an existing `## ... <tag> ...` heading. If missing, prepends a new entry.
3. Checks CMakeLists.txt `project(iron VERSION X.Y.Z ...)` and `set(IRON_VERSION_FULL "...")` against the tag. If either is stale, rewrites them.
4. Emits `changelog_changed`, `cmake_changed`, and `any_changed` outputs via `$GITHUB_OUTPUT`.

The workflow then:

- Commits and pushes to `main` directly if anything changed (no PR, per request).
- **If `cmake_changed=true`**, re-dispatches `release.yml` against the updated `main` via `gh workflow run release.yml -f tag=<tag>`. This rebuilds the release binaries on the fixed `main` so the assets uploaded to the release have the correct `iron --version` output. The existing `release.yml` already supports `workflow_dispatch` with a `tag` input, so no changes were needed there.
- Is idempotent: the script exits 2 (no-op) when everything is already in sync, so re-running against a synced release is harmless. Re-runs are guarded by a per-tag `concurrency` group to prevent two races on the same tag.

## CMakeLists.txt version plumbing

`iron --version` was previously wired to `${PROJECT_VERSION}`, which CMake's `project(iron VERSION ...)` clause only accepts as numeric `MAJOR.MINOR.PATCH[.TWEAK]` — any `-alpha`-style suffix is silently dropped. This PR introduces a parallel `IRON_VERSION_FULL` variable that holds the full display string, and rewires `IRON_VERSION_STRING` to read from it for both the `ironc` and `iron` targets.

The existing CTest check (`PASS_REGULAR_EXPRESSION "^ironc [0-9]"`) still passes because the script strips the leading `v` from the tag before storing it.

## Local use

The script is invokable locally:

```
scripts/update_changelog_from_release.py --tag v1.0.0-alpha --repo victorl2/iron-lang --dry-run
scripts/update_changelog_from_release.py --tag v1.0.0-alpha
```

Exit codes: `0` = something changed on disk, `2` = already in sync, `1` = usage or fetch error.

## Caveats

- The workflow pushes to `main` with `${{ secrets.GITHUB_TOKEN }}`. If `main` becomes branch-protected with required reviews, that token will be rejected and the workflow will need a PAT in a secret instead. Not an issue today.
- `softprops/action-gh-release@v2` replaces existing release assets by name on re-dispatch, so the re-triggered build overwrites the stale binaries on the same release tag.
- The script assumes release tags of shape `v?MAJOR.MINOR.PATCH[-suffix]`. All existing Iron tags follow this.