### PR TITLE
ci(bench): split parallel benchmarks into a concurrent job

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,11 +16,15 @@ on:
 
 jobs:
   benchmark:
+    # Split into two groups per OS so the thread-heavy parallel_/concurrency_/spawn_
+    # benchmarks run concurrently with the sequential ones on a separate runner.
+    # This also prevents the parallel group from polluting sequential timings
+    # by hammering the shared CPU mid-measurement.
+    name: benchmark (${{ matrix.os }}, ${{ matrix.group }})
     strategy:
       matrix:
-        include:
-          - os: ubuntu-24.04
-          - os: macos-26
+        os: [ubuntu-24.04, macos-26]
+        group: [sequential, parallel]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -47,8 +51,18 @@ jobs:
           cmake --build build
 
       - name: Run benchmarks
-        run: bash tests/benchmarks/run_benchmarks.sh --verbose
+        run: |
+          if [ "${{ matrix.group }}" = "parallel" ]; then
+            bash tests/benchmarks/run_benchmarks.sh --verbose --only-parallel
+          else
+            bash tests/benchmarks/run_benchmarks.sh --verbose --skip-parallel
+          fi
 
       - name: Check regression (informational)
         continue-on-error: true
-        run: bash tests/benchmarks/run_benchmarks.sh --check-regression
+        run: |
+          if [ "${{ matrix.group }}" = "parallel" ]; then
+            bash tests/benchmarks/run_benchmarks.sh --check-regression --only-parallel
+          else
+            bash tests/benchmarks/run_benchmarks.sh --check-regression --skip-parallel
+          fi

--- a/tests/benchmarks/run_benchmarks.sh
+++ b/tests/benchmarks/run_benchmarks.sh
@@ -28,6 +28,10 @@ CHECK_REGRESSION=0
 WRITE_JSON=0
 JSON_FILE=""
 COMPARE_MODE=0
+# --only-parallel / --skip-parallel split the suite into two groups so the CI
+# workflow can run them as separate jobs concurrently. A benchmark is considered
+# "parallel" if its directory name starts with parallel_, concurrency_, or spawn_.
+GROUP_FILTER="all"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -56,8 +60,16 @@ while [[ $# -gt 0 ]]; do
             COMPARE_MODE=1
             shift
             ;;
+        --only-parallel)
+            GROUP_FILTER="parallel"
+            shift
+            ;;
+        --skip-parallel)
+            GROUP_FILTER="sequential"
+            shift
+            ;;
         *)
-            echo "Usage: $0 [--problem NAME] [--verbose] [--save-baseline] [--check-regression] [--json FILE] [--compare]"
+            echo "Usage: $0 [--problem NAME] [--verbose] [--save-baseline] [--check-regression] [--json FILE] [--compare] [--only-parallel | --skip-parallel]"
             exit 1
             ;;
     esac
@@ -207,6 +219,29 @@ median() {
     '
 }
 
+# ── Parallel-group membership ──────────────────────────────────────────────
+# A benchmark belongs to the "parallel" group if its directory name starts with
+# parallel_, concurrency_, or spawn_. The CI workflow runs parallel and
+# sequential groups as two concurrent jobs per OS so the thread-heavy
+# benchmarks do not serialize the suite wall-time — and so the sequential
+# benchmarks are not timed on a CPU being hammered by the parallel ones.
+is_parallel_benchmark() {
+    case "$1" in
+        parallel_*|concurrency_*|spawn_*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Returns 0 if the benchmark should be included under the current GROUP_FILTER.
+benchmark_matches_group() {
+    local name="$1"
+    case "$GROUP_FILTER" in
+        all) return 0 ;;
+        parallel) is_parallel_benchmark "$name" ;;
+        sequential) if is_parallel_benchmark "$name"; then return 1; else return 0; fi ;;
+    esac
+}
+
 # ── Verify correctness against expected_output.txt ─────────────────────────
 check_correctness() {
     local actual_output="$1"
@@ -223,6 +258,11 @@ check_correctness() {
 
 # ── Main benchmark loop ──────────────────────────────────────────────────
 echo "=== Iron Benchmark Suite ==="
+case "$GROUP_FILTER" in
+    parallel)   echo "Group: parallel (parallel_*, concurrency_*, spawn_*)" ;;
+    sequential) echo "Group: sequential (excluding parallel_*, concurrency_*, spawn_*)" ;;
+    *)          echo "Group: all" ;;
+esac
 echo ""
 
 total=0
@@ -243,6 +283,11 @@ for problem_dir in "$PROBLEMS_DIR"/*/; do
 
     # Apply filter if --problem was specified
     if [ -n "$FILTER_PROBLEM" ] && [ "$problem_name" != "$FILTER_PROBLEM" ]; then
+        continue
+    fi
+
+    # Apply group filter (--only-parallel / --skip-parallel)
+    if ! benchmark_matches_group "$problem_name"; then
         continue
     fi
 
@@ -473,9 +518,13 @@ for problem_dir in "$PROBLEMS_DIR"/*/; do
 done
 
 # ── Print results ──────────────────────────────────────────────────────────
-for r in "${results[@]}"; do
-    echo "$r"
-done
+# Guarded to avoid `set -u` expansion errors when the group filter matches no
+# benchmarks (e.g. `--only-parallel --problem <sequential-name>`).
+if [ "${#results[@]}" -gt 0 ]; then
+    for r in "${results[@]}"; do
+        echo "$r"
+    done
+fi
 
 echo ""
 echo "Results: $passed/$total passed ($failed failed, $errors errors, $skipped skipped)"
@@ -541,6 +590,10 @@ if [ $CHECK_REGRESSION -eq 1 ]; then
                 continue
             fi
 
+            if ! benchmark_matches_group "$problem_name"; then
+                continue
+            fi
+
             baseline_ratio=$(jq -r ".problems.\"${problem_name}\".ratio // empty" "$baseline_file" 2>/dev/null)
             if [ -z "$baseline_ratio" ]; then
                 echo "  [NEW] $problem_name: no baseline entry"
@@ -549,12 +602,14 @@ if [ $CHECK_REGRESSION -eq 1 ]; then
 
             # Find current ratio from results
             current_ratio=""
-            for r in "${results[@]}"; do
-                if echo "$r" | grep -q "$problem_name"; then
-                    current_ratio=$(echo "$r" | grep -oE '[0-9]+\.[0-9]+x speed' | grep -oE '[0-9]+\.[0-9]+' | head -1)
-                    break
-                fi
-            done
+            if [ "${#results[@]}" -gt 0 ]; then
+                for r in "${results[@]}"; do
+                    if echo "$r" | grep -q "$problem_name"; then
+                        current_ratio=$(echo "$r" | grep -oE '[0-9]+\.[0-9]+x speed' | grep -oE '[0-9]+\.[0-9]+' | head -1)
+                        break
+                    fi
+                done
+            fi
 
             if [ -z "$current_ratio" ]; then
                 echo "  [SKIP] $problem_name: no current result"


### PR DESCRIPTION
## Summary

Stacked follow-up on #18. That PR fixed the flakiness with median-of-30 sampling and per-benchmark iteration tuning, but left the 9 thread-heavy \`parallel_*\` benchmarks untouched because their per-iteration cost structurally exceeds the 50 ms budget. That tail contributes ~13 minutes of wall-time per OS on its own.

This PR splits the suite into two groups that run on separate CI runners so the parallel group no longer serializes the whole suite — and, as a bonus, stops polluting the sequential benchmarks' timings by hammering the shared CPU mid-measurement.

**Base: \`fix/benchmark-sampling\` (#18).** When #18 merges, I'll retarget this PR to \`main\`.

## Changes

### Runner — \`tests/benchmarks/run_benchmarks.sh\`
- Add \`--only-parallel\` / \`--skip-parallel\` flags sharing a single \`GROUP_FILTER\` variable.
- Define "parallel" by directory-name prefix: \`parallel_\`, \`concurrency_\`, \`spawn_\` (30 benchmarks of 139). The remaining 109 run in the sequential group.
- Guard empty-array expansions under \`set -u\` so a group filter that matches zero benchmarks exits cleanly with a \`0/0 passed\` summary instead of erroring.
- Print the active group in the suite header for log clarity:
  \`\`\`
  === Iron Benchmark Suite ===
  Group: parallel (parallel_*, concurrency_*, spawn_*)
  \`\`\`
- Regression check step inherits the same filter so baseline comparisons only look at benchmarks that were actually run.

### Workflow — \`.github/workflows/benchmark.yml\`
- Promote the matrix to 2×2: \`os: [ubuntu-24.04, macos-26] × group: [sequential, parallel]\`. Four jobs run concurrently.
- Name jobs as \`benchmark (<os>, <group>)\` so failures surface the group immediately.
- Each job runs \`--skip-parallel\` or \`--only-parallel\` as appropriate, for both the main run and the regression check.

## Group membership (30 benchmarks)

\`concurrency_parallel_accumulate\`, \`concurrency_parallel_conditional\`, \`concurrency_parallel_fibonacci\`, \`concurrency_parallel_matrix\`, \`concurrency_parallel_sum\`, \`concurrency_pipeline\`, \`concurrency_shared_counter\`, \`concurrency_spawn_captured\`, \`concurrency_spawn_independence\`, \`concurrency_spawn_result\`, \`parallel_collatz_lengths\`, \`parallel_compute_intensive\`, \`parallel_fibonacci\`, \`parallel_fibonacci_tree\`, \`parallel_gcd_batch\`, \`parallel_hash_computation\`, \`parallel_image_blur\`, \`parallel_mandelbrot\`, \`parallel_matrix_multiply\`, \`parallel_nbody_simulation\`, \`parallel_pi_estimation\`, \`parallel_polynomial_eval\`, \`parallel_prime_sieve\`, \`parallel_prime_sieve_chunks\`, \`parallel_ray_trace\`, \`parallel_reduce_sum\`, \`parallel_sort_merge\`, \`parallel_string_search\`, \`spawn_independent_work\`, \`spawn_pipeline_stages\`.

## Test plan

- [x] \`--only-parallel --problem concurrency_parallel_sum\` → included and passes.
- [x] \`--skip-parallel --problem concurrency_parallel_sum\` → correctly filtered out, empty-array path exits cleanly.
- [x] \`--only-parallel --problem remove_duplicates_sorted\` → correctly filtered out (sequential benchmark excluded from the parallel group).
- [x] \`--skip-parallel --problem remove_duplicates_sorted\` → included and passes.
- [x] \`--only-parallel --problem parallel_collatz_lengths\` → included and passes.
- [ ] Full CI run on both groups (landing will trigger it).

## Expected CI impact

- **Sequential group (109 benchmarks):** ~9-10 min per OS.
- **Parallel group (30 benchmarks):** ~13-14 min per OS, dominated by the 9 untuned \`parallel_*\`.
- **Wall-time per OS:** \`max(sequential, parallel) + build\` ≈ **~14-15 min** (down from ~25 min combined in #18).
- **Billed time:** increases modestly (two jobs instead of one per OS, each with its own ~1 min build).