### PR TITLE
ci: split bench-calibrate into matrix cells + merge job

### DIFF
--- a/.github/workflows/bench-calibrate.yml
+++ b/.github/workflows/bench-calibrate.yml
@@ -1,18 +1,32 @@
 name: Bench Calibrate
 
 # Phase 73 Plan 01 (HARDEN-03): on-demand linux-x86_64 benchmark calibration.
-# Runs scripts/bench_audit.sh --platform linux-x86_64 5 on a fresh ubuntu-24.04
-# runner (~18 min wall-clock: 5 rounds of 139 benchmarks) and uploads the
-# aggregated CSV /tmp/58-audit.csv as a named workflow artifact. The artifact
-# is harvested by the Plan 01 Task 2 executor via `gh run download --name ...`
-# and converted into tests/benchmarks/thresholds.linux-x86_64.json using the
-# locked 15% safety margin rule.
+#
+# Structure (Option B, post-73-01-first-run revision):
+# A 2-cell matrix splits the 139-benchmark suite into `sequential` (everything
+# not starting with parallel_/concurrency_/spawn_) and `parallel` (the rest),
+# each running on its own ubuntu-24.04 runner. A follow-up `merge` job
+# downloads both per-group CSVs, concatenates them into a single canonical
+# /tmp/58-audit.csv, and uploads it as the unified artifact consumers depend
+# on.
+#
+# Why Option B (matrix split) instead of a single-runner serial sweep:
+#   - The first 73-01 attempt (workflow run 24429160755) was cancelled by
+#     timeout-minutes: 30 with [run 1/5] still in progress. The plan's
+#     73-CONTEXT.md estimate of "~18 min total for 5 rounds" was off by
+#     10-30x because it conflated benchmark.yml's matrix-split wall-clock
+#     (two concurrent runners) with bench_audit.sh's single-runner serial
+#     sweep of all 139 benchmarks.
+#   - Splitting sequential vs parallel groups across two concurrent runners
+#     restores the same "~two halves in parallel" cost model benchmark.yml
+#     already uses for every PR. Per-cell wall-clock fits comfortably under
+#     the GH Actions 6-hour job ceiling.
 #
 # Why workflow_dispatch and not on-push:
-#   - 18 min per run is too expensive for every PR
-#   - REG-03's "5-minute re-calibration" promise means maintainers re-run this
-#     ad-hoc when benchmark drift is detected, not on a schedule
-#   - No crash/regression artifacts; just aggregated threshold data
+#   - Even split, ~2-5 hours of CI per re-calibration is too expensive for
+#     every PR.
+#   - REG-03's "5-minute re-calibration" promise means maintainers re-run
+#     this ad-hoc when benchmark drift is detected, not on a schedule.
 #
 # Do NOT add `on: schedule` or `on: push` triggers. `workflow_dispatch` only.
 
@@ -21,9 +35,24 @@ on:
 
 jobs:
   calibrate:
-    name: Calibrate (linux-x86_64, 5 rounds)
+    name: Calibrate linux-x86_64 (${{ matrix.group }}, 5 rounds)
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    # 5h 30m budget per matrix cell. Observed in run 24429160755: round 1
+    # of the combined 139-benchmark sweep did not finish in 30 min on
+    # ubuntu-24.04 (>30 min, <= 60 min). Sequential group is ~70% of the
+    # benchmarks; 5 rounds of sequential could approach 5 hours wall-clock
+    # in the worst case. Parallel group is smaller and expected to finish
+    # in well under 2 hours. The 330-minute ceiling leaves ~30 min headroom
+    # under the GH Actions 6-hour hard limit.
+    timeout-minutes: 330
+    strategy:
+      # If one group fails, still let the other finish so we harvest
+      # whatever data we can — the merge job gates on both succeeding and
+      # will not run on partial data, but the raw per-group artifacts are
+      # still valuable for post-mortem.
+      fail-fast: false
+      matrix:
+        group: [sequential, parallel]
 
     steps:
       - uses: actions/checkout@v4
@@ -41,26 +70,81 @@ jobs:
             -G Ninja
           cmake --build build
 
-      - name: Run 5-round bench audit
+      - name: Run 5-round bench audit (${{ matrix.group }} group)
         run: |
           set -u
-          bash scripts/bench_audit.sh --platform linux-x86_64 5
-          echo "--- /tmp/58-audit.csv head ---"
-          head -5 /tmp/58-audit.csv
-          echo "--- /tmp/58-audit.csv row count ---"
-          wc -l /tmp/58-audit.csv
+          bash scripts/bench_audit.sh \
+            --platform linux-x86_64 \
+            --group ${{ matrix.group }} \
+            5
+          echo "--- /tmp/58-audit-${{ matrix.group }}.csv head ---"
+          head -5 /tmp/58-audit-${{ matrix.group }}.csv
+          echo "--- /tmp/58-audit-${{ matrix.group }}.csv row count ---"
+          wc -l /tmp/58-audit-${{ matrix.group }}.csv
 
-      - name: Upload audit CSV artifact
+      - name: Upload per-group audit artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: bench-audit-linux-x86_64-5round-${{ github.run_id }}
+          name: bench-audit-linux-x86_64-5round-${{ matrix.group }}-${{ github.run_id }}
           path: |
-            /tmp/58-audit.csv
-            /tmp/58-audit-run-1.json
-            /tmp/58-audit-run-2.json
-            /tmp/58-audit-run-3.json
-            /tmp/58-audit-run-4.json
-            /tmp/58-audit-run-5.json
+            /tmp/58-audit-${{ matrix.group }}.csv
+            /tmp/58-audit-${{ matrix.group }}-run-1.json
+            /tmp/58-audit-${{ matrix.group }}-run-2.json
+            /tmp/58-audit-${{ matrix.group }}-run-3.json
+            /tmp/58-audit-${{ matrix.group }}-run-4.json
+            /tmp/58-audit-${{ matrix.group }}-run-5.json
+          if-no-files-found: error
+          retention-days: 30
+
+  merge:
+    name: Merge sequential + parallel CSVs
+    needs: calibrate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Download sequential artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: bench-audit-linux-x86_64-5round-sequential-${{ github.run_id }}
+          path: seq/
+
+      - name: Download parallel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: bench-audit-linux-x86_64-5round-parallel-${{ github.run_id }}
+          path: par/
+
+      - name: Merge CSVs into unified /tmp/58-audit.csv
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/merged
+          # Both per-group CSVs share the exact same header (produced by the
+          # same bench_audit.sh Python heredoc). Merge = header from either
+          # one + non-header rows from both. The two groups are disjoint by
+          # construction (is_parallel_benchmark partitions on name prefix),
+          # so there's no row-key collision to resolve.
+          head -1 seq/58-audit-sequential.csv > /tmp/merged/58-audit.csv
+          tail -n +2 seq/58-audit-sequential.csv >> /tmp/merged/58-audit.csv
+          tail -n +2 par/58-audit-parallel.csv >> /tmp/merged/58-audit.csv
+          echo "--- merged /tmp/merged/58-audit.csv head ---"
+          head -5 /tmp/merged/58-audit.csv
+          echo "--- row count ---"
+          wc -l /tmp/merged/58-audit.csv
+          # Sanity: expect at least 130 data rows (139 benchmarks minus a
+          # handful that may have been skipped for build reasons).
+          data_rows=$(( $(wc -l < /tmp/merged/58-audit.csv) - 1 ))
+          echo "data rows: $data_rows"
+          if [ "$data_rows" -lt 130 ]; then
+            echo "ERROR: merged CSV has $data_rows data rows, expected >= 130" >&2
+            exit 1
+          fi
+
+      - name: Upload merged audit artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-audit-linux-x86_64-5round-${{ github.run_id }}
+          path: /tmp/merged/58-audit.csv
           if-no-files-found: error
           retention-days: 30

--- a/scripts/bench_audit.sh
+++ b/scripts/bench_audit.sh
@@ -21,18 +21,35 @@
 # The CSV is consumed by Plan 03 Task 2 to write 'rationale' strings into
 # every benchmark config.json.
 #
-# Usage: bash scripts/bench_audit.sh [--platform {linux-x86_64|macos-arm64|auto}] [runs]
+# Usage: bash scripts/bench_audit.sh [--platform {linux-x86_64|macos-arm64|auto}]
+#                                    [--group {sequential|parallel|all}] [runs]
 #   --platform: CI-runner tag for the output CSV (default: auto via uname).
 #               Phase 69 Plan 05 (REG-03) added this so the next benchmark
 #               drift incident is a 5-minute re-run instead of a 30-minute
 #               debug session. The CSV gains a leading `platform` column
 #               so per-platform thresholds can be split into separate
 #               tests/benchmarks/thresholds.<platform>.json files.
+#   --group:    Benchmark group filter (default: all).
+#               Phase 73 Plan 01 (HARDEN-03, Option B) added this so the
+#               linux calibration can be matrix-split across two concurrent
+#               GH Actions runners instead of running 139 benchmarks
+#               serially on a single runner and blowing past the 30-min job
+#               budget (observed: round 1/5 alone did not finish in 30 min
+#               on ubuntu-24.04). `sequential` passes --skip-parallel to
+#               run_benchmarks.sh; `parallel` passes --only-parallel; `all`
+#               passes no filter (backwards-compat default).
 #   runs:       number of audit rounds (default 5)
 #
-# Outputs:
-#   /tmp/58-audit-run-{1..5}.json  per-run JSON results
-#   /tmp/58-audit.csv              aggregated CSV with columns:
+# Outputs (when --group all, the default):
+#   /tmp/58-audit-run-{1..N}.json  per-run JSON results
+#   /tmp/58-audit.csv              aggregated CSV
+# Outputs (when --group is sequential or parallel):
+#   /tmp/58-audit-{group}-run-{1..N}.json  per-run JSON results
+#   /tmp/58-audit-{group}.csv              aggregated CSV (same schema)
+#
+# CSV columns (identical across all --group values so the downstream merge
+# step in .github/workflows/bench-calibrate.yml can concatenate two CSVs by
+# header-match):
 #     platform, problem, runs_total, runs_used, ratio_min, ratio_max,
 #     ratio_mean, ratio_stddev, variance_pct, iron_ms_mean, c_ms_mean,
 #     pass_count, current_max_ratio,
@@ -44,14 +61,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 RUNNER="$REPO_ROOT/tests/benchmarks/run_benchmarks.sh"
 
-# Argument parsing: --platform flag is optional, runs is positional.
+# Argument parsing: --platform and --group are optional flags, runs is positional.
 # Backwards-compat: `bash scripts/bench_audit.sh 5` still works (positional runs=5).
 PLATFORM="auto"
+GROUP="all"
 RUNS=5
 while [ $# -gt 0 ]; do
     case "$1" in
         --help|-h)
-            sed -n '1,39p' "${BASH_SOURCE[0]}"
+            sed -n '1,55p' "${BASH_SOURCE[0]}"
             exit 0
             ;;
         --platform)
@@ -60,6 +78,14 @@ while [ $# -gt 0 ]; do
             ;;
         --platform=*)
             PLATFORM="${1#--platform=}"
+            shift
+            ;;
+        --group)
+            GROUP="$2"
+            shift 2
+            ;;
+        --group=*)
+            GROUP="${1#--group=}"
             shift
             ;;
         *)
@@ -101,7 +127,36 @@ case "$PLATFORM" in
         ;;
 esac
 
+# --group dispatch: map to the run_benchmarks.sh flag and the output-path prefix.
+# When --group=all (default), keep the legacy /tmp/58-audit.csv path so existing
+# consumers (Phase 69 REG-03 tooling) still work. When sequential/parallel,
+# suffix the output paths so two CI matrix cells can write to the same runner
+# workspace (or for local back-to-back invocations) without clobbering.
+RUNNER_GROUP_FLAG=""
+OUT_PREFIX="/tmp/58-audit"
+case "$GROUP" in
+    all)
+        RUNNER_GROUP_FLAG=""
+        OUT_PREFIX="/tmp/58-audit"
+        ;;
+    sequential)
+        RUNNER_GROUP_FLAG="--skip-parallel"
+        OUT_PREFIX="/tmp/58-audit-sequential"
+        ;;
+    parallel)
+        RUNNER_GROUP_FLAG="--only-parallel"
+        OUT_PREFIX="/tmp/58-audit-parallel"
+        ;;
+    *)
+        echo "ERROR: invalid --group: $GROUP" >&2
+        echo "  valid values: sequential, parallel, all" >&2
+        exit 1
+        ;;
+esac
+
 echo "Platform: $PLATFORM"
+echo "Group:    $GROUP (runner flag: ${RUNNER_GROUP_FLAG:-<none>})"
+echo "Output prefix: $OUT_PREFIX"
 
 if [ ! -x "$RUNNER" ]; then
     echo "ERROR: $RUNNER not found or not executable"
@@ -121,18 +176,24 @@ echo ""
 # expected during the audit — we only care about the JSON output, not the
 # pass/fail summary. Only abort on rc >= 100 (infra failures).
 for i in $(seq 1 "$RUNS"); do
-    out="/tmp/58-audit-run-$i.json"
+    out="$OUT_PREFIX-run-$i.json"
     echo "[run $i/$RUNS] writing $out ..."
-    bash "$RUNNER" --json "$out" >"/tmp/58-audit-run-$i.log" 2>"/tmp/58-audit-run-$i.err"
+    if [ -n "$RUNNER_GROUP_FLAG" ]; then
+        bash "$RUNNER" "$RUNNER_GROUP_FLAG" --json "$out" \
+            >"$OUT_PREFIX-run-$i.log" 2>"$OUT_PREFIX-run-$i.err"
+    else
+        bash "$RUNNER" --json "$out" \
+            >"$OUT_PREFIX-run-$i.log" 2>"$OUT_PREFIX-run-$i.err"
+    fi
     rc=$?
     if [ "$rc" -ge 100 ]; then
         echo "  ABORT: runner exited with rc=$rc (infrastructure failure)"
-        head -20 "/tmp/58-audit-run-$i.err"
+        head -20 "$OUT_PREFIX-run-$i.err"
         exit 1
     fi
     if [ ! -f "$out" ]; then
         echo "ABORT: $out was not produced (rc=$rc)"
-        head -20 "/tmp/58-audit-run-$i.err"
+        head -20 "$OUT_PREFIX-run-$i.err"
         exit 1
     fi
     count=$(jq '.benchmarks | length' "$out" 2>/dev/null || echo "?")
@@ -140,7 +201,7 @@ for i in $(seq 1 "$RUNS"); do
 done
 
 echo ""
-echo "=== Aggregating $RUNS runs into /tmp/58-audit.csv ==="
+echo "=== Aggregating $RUNS runs into ${OUT_PREFIX}.csv ==="
 
 # 2) Aggregate with trimmed-mean robustness.
 #    For each benchmark, drop the min and max across the N runs, then compute
@@ -150,16 +211,17 @@ echo "=== Aggregating $RUNS runs into /tmp/58-audit.csv ==="
 #    Rationale: machine-level noise on ~15ms-runtime benchmarks produces
 #    single-run outliers that distort a naive 5-sample mean; trimming min+max
 #    removes those outliers while keeping enough samples for a useful stddev.
-python3 - "$RUNS" "$PLATFORM" <<'PYEOF'
+python3 - "$RUNS" "$PLATFORM" "$OUT_PREFIX" <<'PYEOF'
 import json
 import math
 import sys
 
 RUNS = int(sys.argv[1])
 platform_tag = sys.argv[2]
+out_prefix = sys.argv[3]
 runs_data = []
 for i in range(1, RUNS + 1):
-    path = f"/tmp/58-audit-run-{i}.json"
+    path = f"{out_prefix}-run-{i}.json"
     with open(path) as f:
         runs_data.append(json.load(f))
 
@@ -198,7 +260,7 @@ def trimmed_mean_std(values):
         stddev = 0.0
     return mean, stddev, m
 
-with open("/tmp/58-audit.csv", "w") as out:
+with open(f"{out_prefix}.csv", "w") as out:
     # Header: trimmed-aware statistics + raw per-run ratios for auditability.
     header_cols = [
         "platform",
@@ -248,15 +310,16 @@ with open("/tmp/58-audit.csv", "w") as out:
                 row.append("")
         out.write(",".join(row) + "\n")
 
-print(f"Wrote /tmp/58-audit.csv ({len(by_problem)} problems, {RUNS} runs each, trimmed-mean over middle {RUNS - 2})")
+print(f"Wrote {out_prefix}.csv ({len(by_problem)} problems, {RUNS} runs each, trimmed-mean over middle {RUNS - 2})")
 PYEOF
 
 echo ""
 echo "=== Audit complete ==="
 echo "Platform:          $PLATFORM"
-echo "Raw per-run data:  /tmp/58-audit-run-{1..$RUNS}.json"
-echo "Aggregated CSV:    /tmp/58-audit.csv"
+echo "Group:             $GROUP"
+echo "Raw per-run data:  ${OUT_PREFIX}-run-{1..$RUNS}.json"
+echo "Aggregated CSV:    ${OUT_PREFIX}.csv"
 echo ""
-echo "binary_tree_diameter row:"
-head -1 /tmp/58-audit.csv
-grep "^binary_tree_diameter," /tmp/58-audit.csv || echo "  (not found — audit is broken)"
+echo "First data row:"
+head -1 "${OUT_PREFIX}.csv"
+head -2 "${OUT_PREFIX}.csv" | tail -1 || echo "  (empty — audit is broken)"


### PR DESCRIPTION
## Summary

Finishes Option B for HARDEN-03 Plan 73-01 after the first attempt (workflow run [24429160755](https://github.com/victorl2/iron-lang/actions/runs/24429160755)) was cancelled by `timeout-minutes: 30` with `[run 1/5]` still running. The `bench_audit.sh` single-runner serial sweep of all 139 benchmarks does not fit any reasonable CI job budget on `ubuntu-24.04` — 73-CONTEXT.md's 18-minute estimate was off by ~10–30×.

This PR restores the same "two halves in parallel" cost model `benchmark.yml` already uses for every PR by matrix-splitting the calibration into `sequential` (109 benchmarks, everything not starting with `parallel_`/`concurrency_`/`spawn_`) and `parallel` (the remaining 30) across two concurrent runners, with a follow-up `merge` job that concatenates the per-group CSVs into the canonical unified artifact.

- **`scripts/bench_audit.sh`** gains `--group {sequential,parallel,all}`. `sequential` passes `--skip-parallel` to `run_benchmarks.sh`, `parallel` passes `--only-parallel`, `all` passes no filter (backwards-compat default). Output paths are suffixed when non-`all` (`/tmp/58-audit-sequential{.csv,-run-*.json}` etc.) so the two matrix cells can't clobber each other. CSV schema is identical across all three values so the downstream merge step can concatenate by header-match.
- **`.github/workflows/bench-calibrate.yml`** is rewritten: `strategy.matrix.group: [sequential, parallel]` with `fail-fast: false` and `timeout-minutes: 330` per cell (5h 30m, ~30m headroom under the 6h job ceiling), plus a new `merge` job (`needs: calibrate`) that downloads both per-group artifacts, concatenates them (header + seq rows + par rows), asserts ≥130 data rows, and uploads the unified `bench-audit-linux-x86_64-5round-<run_id>` artifact that downstream consumers (Plan 73-03 docs + JSON harvest) already expect.

### Wall-clock expectation

Matrix cells run concurrently on separate runners → total wall-clock = `max(sequential_cell, parallel_cell)`. Sequential cell dominates (109 vs 30 benchmarks). Realistic estimate: **~2–3.5h total**, not 5h. The 330-min per-cell timeout is a ceiling, not the expected run time.

### Trimmed-mean methodology

Unchanged. Per-benchmark rows still come from 5 samples on the same runner; there is no cross-row aggregation, so splitting disjoint groups across two ubuntu-24.04 runners does not affect per-row statistics.

## Test plan

- [x] `bash -n scripts/bench_audit.sh` clean
- [x] `bash scripts/bench_audit.sh --help` renders the new `--group` section
- [x] `bash scripts/bench_audit.sh --group bogus ...` errors with `exit=1` and a usage hint
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the workflow parses; jobs = `['calibrate', 'merge']`; matrix = `{'group': ['sequential', 'parallel']}`; `merge needs: calibrate`
- [x] Triggers confirmed `workflow_dispatch`-only (no `on: push` / `on: schedule`)
- [x] Artifact names unique per run (`-sequential-<id>`, `-parallel-<id>`, `-<id>`)
- [ ] End-to-end run confirming the matrix fits in budget and the merge job produces a ≥130-row CSV — the first post-merge calibration run is live at https://github.com/victorl2/iron-lang/actions/runs/24433918262 against the phase branch (which already has these commits cherry-picked in). Will update with results.