### PR TITLE
fix(fuzz): silence LSan on iron_seed_blobs POST_BUILD

### DIFF
--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -132,11 +132,23 @@ set(_FUZZ_CORPUS_DIR      "${CMAKE_CURRENT_BINARY_DIR}/corpus")
 # Uses cmake -E copy_directory for the parser corpus (not symlinks — Pitfall 6
 # in 68-RESEARCH.md explains why symlinks break on Windows and across
 # `git clone`). Marginal disk cost (~5 MB per build dir).
+#
+# ASAN_OPTIONS=detect_leaks=0 is load-bearing: iron_seed_blobs is built with
+# -fsanitize=address,undefined and parses every .iron file in tests/integration
+# through the full pipeline. The parser's documented batch-compiler tradeoff
+# (see src/parser/parser.c:15-49 "FIX-03 / AUDIT-04 §1: SAFETY") deliberately
+# leaks stb_ds backing buffers at process exit for 17 arrput-into-AST transfer
+# sites — Iron_Parse_Pattern in match-statement bodies is one of them. Without
+# this env override, LSan turns every seed-tool invocation on a Linux runner
+# (where LSan is on by default) into a non-zero exit and blocks the fuzz build
+# at the POST_BUILD step. Mirrors the runtime detect_leaks=0 already set in
+# .github/workflows/fuzz.yml for the libFuzzer step.
 add_custom_command(TARGET iron_seed_blobs POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E make_directory "${_FUZZ_CORPUS_DIR}/parser"
     COMMAND ${CMAKE_COMMAND} -E make_directory "${_FUZZ_CORPUS_DIR}/typecheck"
     COMMAND ${CMAKE_COMMAND} -E make_directory "${_FUZZ_CORPUS_DIR}/hir_to_lir"
-    COMMAND $<TARGET_FILE:iron_seed_blobs>
+    COMMAND ${CMAKE_COMMAND} -E env "ASAN_OPTIONS=detect_leaks=0"
+            $<TARGET_FILE:iron_seed_blobs>
             "${_FUZZ_INTEGRATION_DIR}"
             "${_FUZZ_CORPUS_DIR}"
     COMMENT "Seeding fuzz corpora from tests/integration/*.iron")


### PR DESCRIPTION
## Summary

Unblocks the nightly fuzz workflow. The first-ever nightly run ([24440075085](https://github.com/victorl2/iron-lang/actions/runs/24440075085), 2026-04-15 06:33 UTC) failed all three matrix cells (parser/typecheck/hir_to_lir) at the \`Build fuzz target + seed blobs\` step in ~35s with LSan reporting **2,803,232 bytes in 7,398 allocations** leaked from \`iron_seed_blobs\` at process exit, making ninja treat the build as failed.

## Root cause

The leaks are **pre-existing and deliberate**. \`src/parser/parser.c:15-49\` documents a batch-compiler tradeoff: the parser uses \`stb_ds arrput\` at 17 sites to build variable-size arrays and ownership-transfers them into arena-allocated AST nodes. When \`iron_arena_free\` runs, the nodes are reclaimed but the stb_ds backing buffers leak to process exit. A full fix would migrate all 17 sites to arena storage and is **explicitly out of Phase 67 scope**.

The relevant stack (both CI and local repro):

\`\`\`
stbds_arrgrowf (src/vendor/stb_ds.h:785, realloc)
  <- iron_parse_pattern (src/parser/parser.c:1486 & 1479)
  <- iron_parse_match_stmt (parser.c:1580)
  <- iron_parse_stmt/block/func/decl/iron_parse
  <- try_seed_blob (tests/fuzz/seed_blobs.c:135)
\`\`\`

\`iron_seed_blobs\` runs the full parser on every .iron file in \`tests/integration/\` as part of its POST_BUILD custom command, so every per-file leak accumulates and surfaces at exit. Phase 67-08 ([6e21849](https://github.com/victorl2/iron-lang/commit/6e21849)) added a \`match\` canary to the integration suite; Phase 68-06 ([ac62936](https://github.com/victorl2/iron-lang/commit/ac62936)) landed the nightly fuzz workflow. The leak was **latent from day 0 of the fuzz workflow** and fired the moment the first nightly actually ran.

## Fix

Wrap the POST_BUILD \`iron_seed_blobs\` invocation with \`cmake -E env "ASAN_OPTIONS=detect_leaks=0"\`, mirroring the runtime env var already set on the libFuzzer step in \`.github/workflows/fuzz.yml\`. This:

- Keeps AddressSanitizer's buffer-safety checks active on \`seed_blobs\` itself (we still want those catching real bugs).
- Acknowledges that the parser's deliberate batch-compiler leaks are not \`seed_blobs\`' problem to solve.
- Is **self-contained** in the CMake custom command: developers running \`cmake --build build\` locally on Linux with \`IRON_ENABLE_FUZZING=ON\` hit the same silencing without needing to propagate env vars through their shell.
- Does **not** touch \`parser.c\` — the 17-site refactor stays out of scope.

## Validation

Local repro on macOS with Homebrew clang 21 (LSan forced on via \`ASAN_OPTIONS=detect_leaks=1\`):

| Scenario | LSan output | Exit | Parsed files |
|---|---|---|---|
| Baseline (no override) | \`SUMMARY: AddressSanitizer: 2,822,744 byte(s) leaked in 7,425 allocation(s)\` | 0 (macOS) / 23 (Linux) | n/a — reports before finishing |
| With \`cmake -E env "ASAN_OPTIONS=detect_leaks=0"\` | none | 0 | parser=382 typecheck=381 hir_to_lir=381 |

## Test plan

- [x] Reproduce the CI leak signature locally (2.8MB / ~7.4k allocations — matches within rounding)
- [x] Apply the fix
- [x] Confirm \`cmake -E env\` override wins over an outer \`ASAN_OPTIONS=detect_leaks=1\` parent env
- [x] Confirm \`iron_seed_blobs\` still parses the full integration corpus (382 files) with the override in place
- [ ] Merge + re-trigger nightly fuzz (\`gh workflow run fuzz.yml\`) to confirm all three matrix cells reach the \`Run libFuzzer\` step