### PR TITLE
Fix install.sh --version pin and sweep ironlang.org refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,13 +67,13 @@ shipped binding.
 ### Install
 
 ```bash
-curl -fsSL https://ironlang.org/install.sh | bash
+curl --proto '=https' --tlsv1.2 -sSfL https://ironlang.dev/install.sh | sh
 ```
 
 Pin to a specific version:
 
 ```bash
-curl -fsSL https://ironlang.org/install.sh | bash -s -- --version v3.1.0-alpha
+curl --proto '=https' --tlsv1.2 -sSfL https://ironlang.dev/install.sh | sh -s -- --version v3.1.0-alpha
 ```
 
 ## v3.0.0-alpha — Method Ergonomics (2026-04-23)
@@ -318,10 +318,10 @@ window because there are no published consumers yet.)*
 ### Install
 
 ```bash
-curl -fsSL https://ironlang.org/install.sh | bash
+curl --proto '=https' --tlsv1.2 -sSfL https://ironlang.dev/install.sh | sh
 ```
 
-See the [Raylib getting-started guide](https://ironlang.org/raylib/guide/)
+See the [Raylib getting-started guide](https://ironlang.dev/raylib/guide/)
 for building your first game.
 
 ## v2.0.0-alpha — Iron Builds Real Games (2026-04-19)
@@ -336,7 +336,7 @@ First-class **raylib** binding for Iron. You can now write games in Iron that co
 - **Vendored raylib 6.0** — builds per-source (no amalgamation), compile-time ABI enforcement (413 `_Static_assert`s pin every `sizeof` + `offsetof` between `Iron_<T>` and raylib `<T>` so any drift is a hard clang error).
 - **5 canonical examples**: `pong` (full state machine + paddles + bounce audio + web-ready frame-loop split), `rotating_cube`, `model_viewer`, `post_fx`, `raylib_showcase` (12-category end-to-end demo).
 - **Web target**: `iron build --target=web` produces `dist/web/index.{html,js,wasm}` from the same Iron source, including canonical `while not Window.should_close()` main-loop lifting into a web-safe frame state.
-- **Documentation site** (docs.ironlang.org/raylib): landing, getting-started guide, 14-page category API reference, examples gallery.
+- **Documentation site** (ironlang.dev/raylib): landing, getting-started guide, 14-page category API reference, examples gallery.
 
 #### Runtime improvements that landed with this milestone
 
@@ -363,10 +363,10 @@ First-class **raylib** binding for Iron. You can now write games in Iron that co
 #### Install
 
 ```bash
-curl -fsSL https://ironlang.org/install.sh | bash
+curl --proto '=https' --tlsv1.2 -sSfL https://ironlang.dev/install.sh | sh
 ```
 
-See the [Raylib getting-started guide](https://ironlang.org/raylib/guide/) for building your first game.
+See the [Raylib getting-started guide](https://ironlang.dev/raylib/guide/) for building your first game.
 
 ## v1.2.0-alpha — Networking Foundation, URL Module & Tuple Returns (2026-04-11)
 

--- a/docs/release-notes/v2.2.md
+++ b/docs/release-notes/v2.2.md
@@ -268,8 +268,8 @@ See `.planning/REQUIREMENTS.md` for the full v2.3+ backlog.
 ## Install
 
 ```bash
-curl -fsSL https://ironlang.org/install.sh | bash
+curl --proto '=https' --tlsv1.2 -sSfL https://ironlang.dev/install.sh | sh
 ```
 
-See the [Raylib getting-started guide](https://ironlang.org/raylib/guide/)
+See the [Raylib getting-started guide](https://ironlang.dev/raylib/guide/)
 for building your first game.

--- a/docs/release-notes/v3.md
+++ b/docs/release-notes/v3.md
@@ -408,15 +408,15 @@ codemod and verified your build passes. There is no silent upgrade path.
 ## Install
 
 ```bash
-curl -fsSL https://ironlang.org/install.sh | bash
+curl --proto '=https' --tlsv1.2 -sSfL https://ironlang.dev/install.sh | sh
 ```
 
 Pin to a specific version:
 
 ```bash
-curl -fsSL https://ironlang.org/install.sh | bash -s -- --version v3.0.0-alpha
+curl --proto '=https' --tlsv1.2 -sSfL https://ironlang.dev/install.sh | sh -s -- --version v3.0.0-alpha
 ```
 
 See the [migration guide](../site/migration-v2-to-v3.md) before upgrading
-from v2.2. See the [Raylib getting-started guide](https://ironlang.org/raylib/guide/)
+from v2.2. See the [Raylib getting-started guide](https://ironlang.dev/raylib/guide/)
 for building your first game.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,7 +6,52 @@ IRON_HOME="$HOME/.iron"
 INSTALL_DIR="$IRON_HOME/bin"
 ENV_FILE="$IRON_HOME/env"
 
+usage() {
+    cat <<EOF
+Iron installer.
+
+Usage: install.sh [--version VERSION]
+
+Options:
+  --version VERSION   Install a specific release tag (e.g. v3.0.0-alpha or
+                      3.0.0-alpha). Default: the latest release.
+  -h, --help          Show this help and exit.
+EOF
+}
+
 main() {
+    REQUESTED_VERSION=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --version)
+                shift
+                if [ $# -eq 0 ]; then
+                    echo "Error: --version requires a value (e.g. v3.0.0-alpha)" >&2
+                    exit 1
+                fi
+                REQUESTED_VERSION="$1"
+                shift
+                ;;
+            --version=*)
+                REQUESTED_VERSION="${1#--version=}"
+                if [ -z "$REQUESTED_VERSION" ]; then
+                    echo "Error: --version requires a value (e.g. v3.0.0-alpha)" >&2
+                    exit 1
+                fi
+                shift
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                echo "Error: unknown argument: $1" >&2
+                usage >&2
+                exit 1
+                ;;
+        esac
+    done
+
     # Detect OS
     OS="$(uname -s)"
     case "$OS" in
@@ -25,16 +70,23 @@ main() {
 
     TARGET="${PLATFORM}-${ARCH}"
 
-    # Get latest release version
-    if command -v curl > /dev/null 2>&1; then
-        VERSION="$(curl -sSf "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed 's/.*"tag_name": *"v\{0,1\}\([^"]*\)".*/\1/')"
-    else
+    # curl is needed for both the version probe and the tarball download.
+    if ! command -v curl > /dev/null 2>&1; then
         echo "Error: curl is required" >&2
         exit 1
     fi
 
+    # Resolve version. Explicit --version wins; otherwise read the latest tag
+    # from the GitHub releases API. Strip an optional leading "v" so the rest
+    # of the script can compose URLs from "${VERSION}" and "v${VERSION}".
+    if [ -n "$REQUESTED_VERSION" ]; then
+        VERSION="${REQUESTED_VERSION#v}"
+    else
+        VERSION="$(curl -sSf "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed 's/.*"tag_name": *"v\{0,1\}\([^"]*\)".*/\1/')"
+    fi
+
     if [ -z "$VERSION" ]; then
-        echo "Error: Could not determine latest release version" >&2
+        echo "Error: Could not determine release version" >&2
         exit 1
     fi
 
@@ -169,4 +221,4 @@ ENVEOF
     echo "  iron build --target=web --help    # web builds ready"
 }
 
-main
+main "$@"


### PR DESCRIPTION
Follow-up to #45. Two related fixes that didn't make it into that squash-merge:

## 1. `install.sh --version` now actually pins

Before this PR, the installer's `--version VALUE` flag was a silent no-op:

- `main` was invoked as `main` rather than `main "$@"`, so any args from `sh -s -- --version v3.0.0-alpha` never reached the function.
- The body of `main` had no flag-parsing code; it always queried `/releases/latest`.

This means every "Pin to a specific version" recipe ever published in release notes (v3.0, v3.1) installed the latest release instead of the requested one. This PR fixes both halves:

- New top-level `usage()` helper.
- POSIX-sh arg-parsing loop in `main` recognizing `--version VALUE`, `--version=VALUE`, `-h`/`--help`, and rejecting unknown args.
- `main "$@"` at the call site so curl-pipe-sh `-s -- args` propagate.
- Version resolution branches on `REQUESTED_VERSION`: explicit value wins (with optional leading `v` stripped); otherwise the existing `/releases/latest` path runs.
- `curl` availability check moved out of the latest-fetch branch since both paths need it.

**Smoke-tested locally:**

| Invocation | Result |
|---|---|
| `--help` | exits 0, prints usage |
| `--bogus` | exits 1, prints `unknown argument` + usage on stderr |
| `--version` (no value) | exits 1, prints requires-a-value error |
| `--version v3.0.0-alpha` | downloads `v3.0.0-alpha` tarball into sandbox `HOME` |
| `--version=v2.2.0-alpha` | downloads `v2.2.0-alpha` tarball into sandbox `HOME` |

## 2. `ironlang.org` -> `ironlang.dev` sweep

Repo files updated (`CHANGELOG.md`, `docs/release-notes/v3.md`, `docs/release-notes/v2.2.md`):

- All `ironlang.org` references replaced with `ironlang.dev`.
- `docs.ironlang.org/raylib` collapsed to `ironlang.dev/raylib` (no `docs.*` subdomain was ever deployed).
- Curl-pipe form aligned with the rustup-style command standardized in #45, so the doc copies stay byte-consistent with the live release bodies.

Companion edits to live release bodies (v2.0.0-alpha, v2.2.0-alpha, v3.0.0-alpha, v3.1.0-alpha) were applied via `gh release edit` and are not part of this commit. Older releases (v1.x, v0.0.x) had no install or domain references and were not touched.

## Verification

- `grep -rn ironlang.org` in the repo returns nothing.
- `gh release view` for each edited release shows no `ironlang.org` references.
- `sh -n scripts/install.sh` passes; all five flag paths above exit as expected.

## Test plan

- [ ] Re-dispatch `release.yml` after merge so the served `install.sh` carries the `--version` fix (the in-flight `https://ironlang.dev/install.sh` is regenerated from `scripts/install.sh` on each pages deploy, so the merge alone redeploys the script).
- [ ] After deploy: `curl --proto '=https' --tlsv1.2 -sSfL https://ironlang.dev/install.sh | sh -s -- --version v3.0.0-alpha` installs v3.0.0-alpha specifically (not latest).