### PR TITLE
Bump version stamp and add release notes for the next alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,82 @@
 All notable changes to Iron are published as [GitHub releases](https://github.com/victorl2/iron-lang/releases).
 This file is generated from those release notes automatically on each publish.
 
+## v3.3.0-alpha: Editor Support (2026-05-04)
+
+## Iron v3.3.0-alpha: Editor Support
+
+*Released: 2026-05-04*
+
+First-class editor support: a Language Server Protocol 3.17
+implementation (`ironls`), a tree-sitter grammar, and bundled extensions
+for VSCode, Neovim, and Zed. The same `iron_compiler` static library
+that powers `ironc` powers the LSP, so every diagnostic span and error
+code your editor surfaces matches what the compiler produces
+byte-for-byte. Inherits everything in v3.2 (library authoring polish:
+ten library-authoring fixes #47–#56). Pure-superset guard against v3.0
+holds: every program that compiled on v3.2 still compiles on v3.3.
+
+### LSP server (`ironls`)
+
+- New `ironls` binary built from the same `iron_compiler` static
+  library as `ironc`. CI runs a byte-identical parity gate
+  (`test_parity_ironc_lsp`) on every commit — a drift between the LSP
+  and the compiler is a merge-blocking failure.
+- Implements LSP 3.17: diagnostics (push + pull), hover,
+  goto-definition / declaration / type-definition, completion (six
+  context-classified buckets), document and workspace symbols,
+  references, rename (with prepare), semantic tokens, formatting,
+  range formatting, code actions (ten quick fixes), type hierarchy
+  (supertypes + subtypes), work-done progress, cancellation.
+- Out-of-process supervisor with a 5-in-60s crash circuit breaker.
+  Per-document AST worker threads with a coalescing 250ms debounce.
+  `SIGABRT` recovery via `sigsetjmp` + thread-local document slot;
+  one bad document gets quarantined after the second strike instead
+  of crashing the server.
+- Observability: structured trace events, RSS sampling, parent-watch
+  (server exits if the editor dies), crash dumps. An 8-hour nightly
+  memory-soak gate runs in CI; PRs run a 30-minute short-soak.
+
+### Tree-sitter grammar
+
+- `grammars/tree-sitter/iron/grammar.js` covers the full v3 keyword
+  roster (44 keywords). Highlight queries (`highlights.scm`),
+  local-scope resolution (`locals.scm`), and fold ranges
+  (`folds.scm`) ship as companion files.
+- Drift-guarded against the C lexer and the TextMate grammar by
+  `test_grammar_keyword_drift_*` invariants.
+- Built as a portable `iron.wasm` artifact attached to each release.
+
+### Editor extensions
+
+- **VSCode**: "Iron Language Support" in the Marketplace, or install
+  the bundled `iron-lsp-*.vsix` directly. Override the binary path
+  via `iron-lsp.serverPath`.
+- **Neovim**: filetype plugin + LSP client snippet under
+  `editors/neovim/`. Override the binary path via
+  `cmd = { "/path/to/ironls" }`.
+- **Zed**: "Iron LSP" in the extensions panel. The extension
+  downloads `ironls` from the matching release and verifies its
+  SHA-256 before spawning. Override under
+  `lsp."iron-lsp".binary.path`.
+
+### Performance & correctness gates
+
+- **Parity** (`test_parity_ironc_lsp`): byte-identical diagnostic
+  stream between LSP and compiler.
+- **Memory soak**: < 5 MiB/hr growth, < 800 MiB peak across 28,800
+  simulated edit events (8h nightly).
+- **Cold compile**: ~5ms on a 500-LOC fixture.
+- **Cancellation latency**: in-flight compile observes the cancel
+  flag within microseconds.
+
+### Documentation
+
+- New `/lsp/` page on ironlang.dev with feature list, editor setup
+  walk-throughs, configuration overrides, and the parity guarantee.
+- LSP architecture and concurrency model documented in
+  `src/lsp/lsp.h` and the README.
+
 ## v3.2.0-alpha: Library Authoring Polish (2026-05-01)
 
 ## Iron v3.2.0-alpha: Library Authoring Polish

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(iron VERSION 3.1.1 LANGUAGES C)
 # so the suffixed form lives in its own variable and is baked into the binaries
 # as IRON_VERSION_STRING below. Both this line and the project() line above are
 # kept in sync with the latest GitHub release by .github/workflows/changelog-on-release.yml.
-set(IRON_VERSION_FULL "3.1.1-alpha")
+set(IRON_VERSION_FULL "3.3.0-alpha")
 
 # ── Version info baked at compile time ─────────────────────────────────────
 execute_process(

--- a/docs/release-notes/v3.3.md
+++ b/docs/release-notes/v3.3.md
@@ -1,0 +1,195 @@
+# Iron v3.3.0-alpha: Editor Support
+
+*Released: 2026-05-04*
+
+Iron v3.3 ships first-class editor support: a Language Server Protocol
+3.17 implementation (`ironls`), a tree-sitter grammar, and bundled
+extensions for VSCode, Neovim, and Zed. The same `iron_compiler` static
+library that powers `ironc` powers the LSP, so every diagnostic span
+and error code your editor surfaces matches what the compiler produces
+byte-for-byte. v3.3 inherits everything in [v3.2](./v3.2.md) (library
+authoring polish: ten library-authoring fixes #47–#56). Pure-superset
+guard against v3.0 holds: every program that compiled on v3.2 still
+compiles on v3.3.
+
+## At a glance
+
+- **`ironls` binary** ships next to `ironc` and `iron`. Built from the
+  same compiler library — no parallel reimplementation, no drift.
+- **LSP 3.17 surface**: diagnostics, hover, goto-definition, completion,
+  document and workspace symbols, references, rename (with prepare),
+  semantic tokens, formatting, code actions, type hierarchy, work-done
+  progress, cancellation.
+- **Tree-sitter grammar** at `grammars/tree-sitter/iron/` covers the
+  full v3 keyword roster (44 keywords including `init`, `mut`, `patch`,
+  `pub`, `pure`, `readonly`). Drift-guarded against the lexer and the
+  TextMate grammar by CI invariants.
+- **Three editor extensions**:
+  - VSCode: search "Iron Language Support" or install the bundled
+    `.vsix` from the release.
+  - Neovim: built-in LSP client + filetype plugin under
+    `editors/neovim/`.
+  - Zed: search "Iron LSP" in the extensions panel.
+- **Out-of-process supervisor** with a 5-in-60s crash circuit breaker;
+  RSS sampling, parent-watch, structured trace events, and crash dumps
+  ship as standard observability.
+- **Memory-soak gate** in CI: an 8-hour soak run (28,800 events) with a
+  growth-rate regression detector runs nightly; PRs run a 30-minute
+  short-soak.
+
+## The parity guarantee
+
+The defining invariant: `ironls` and `ironc` must never disagree on
+what's wrong with a `.iron` file. Both binaries link the same
+`iron_compiler` static library and route through the same lexer, parser,
+resolver, and typechecker. CI runs `test_parity_ironc_lsp` on every
+commit — it lexes, parses, and analyzes a fixture corpus through both
+binaries and asserts the diagnostic stream is byte-identical. A drift
+fails the merge gate, not silently ships.
+
+## LSP feature surface
+
+The `ironls` server implements the v3.17 protocol and supports the
+following requests / notifications:
+
+- **Document sync**: `textDocument/{didOpen,didChange,didClose,didSave}`,
+  `workspace/didChangeWatchedFiles` for `**/*.iron`, `**/iron.toml`,
+  `**/iron.lock`.
+- **Diagnostics**: `textDocument/publishDiagnostics` (push) and
+  `textDocument/diagnostic` (pull, used by VSCode 1.95+ and Zed).
+  Coalesced 250ms debounce per document — fast keystrokes don't
+  thrash the worker.
+- **Navigation**: `textDocument/{declaration,definition,
+  typeDefinition,references}`, `textDocument/documentSymbol`,
+  `workspace/symbol`.
+- **Hover & signature**: `textDocument/hover` (Iron-formatted type
+  signatures), `textDocument/signatureHelp` (active parameter
+  highlighting at call sites).
+- **Completion**: `textDocument/completion` with six buckets
+  (in-scope, member-after-dot, keyword, builtin, stdlib, snippet),
+  context-classified so `EXPR_HEAD` shows keywords and
+  `MEMBER_AFTER_DOT` shows methods on the receiver type.
+- **Edits**: `textDocument/{formatting,rangeFormatting}` route through
+  `ironc fmt`; `textDocument/{rename,prepareRename}` for safe
+  project-wide renames; `textDocument/codeAction` exposes ten quick
+  fixes seeded by analyzer diagnostics.
+- **Type hierarchy**: `textDocument/prepareTypeHierarchy`,
+  `typeHierarchy/{supertypes,subtypes}`. Walks `extends`/`impl`
+  relationships and patch declarations.
+- **Cancellation**: `$/cancelRequest` is honored at lex/parse/analyze
+  pass boundaries via a cooperative `_Atomic bool` flag — large-file
+  edits cancel in milliseconds, not after the next compile finishes.
+- **Work-done progress**: `$/progress` for long-running operations
+  (workspace symbol scan, multi-file references), so editors render
+  progress bars instead of hanging.
+
+## Architecture
+
+`ironls` runs as a single LSP server process with an out-of-process
+supervisor. The supervisor forks the worker on startup, proxies stdin
+and stdout, and respawns the worker on crash with exponential backoff.
+A 5-in-60-seconds circuit breaker exits the supervisor cleanly so a
+broken `.iron` corpus can't fork-bomb the editor.
+
+Inside the worker:
+
+- **Per-document AST worker thread** with a coalescing mailbox. A
+  burst of `didChange` events collapses into a single re-compile after
+  a 250 ms idle window.
+- **`SIGABRT` recovery** via `sigsetjmp` + thread-local document slot.
+  An assertion failure inside a single document's compile aborts that
+  compile, marks the document quarantined after the second strike,
+  and notifies the editor via `window/showMessage`. Other documents
+  keep working.
+- **Arena-per-compile lifetime**. Tokens, AST, scope tree, and
+  diagnostics live on a per-document arena that gets freed at the end
+  of each compile. No per-keystroke leak, no shared mutable state.
+- **Long-lived workspace state** (`workspace_index`, `stdlib_cache`,
+  `dep_map`) sits above the arena boundary with explicit ownership.
+
+## Tree-sitter grammar
+
+The grammar at `grammars/tree-sitter/iron/grammar.js` covers the full
+v3 surface: `init`, `mut`, `patch`, `pub`, `pure`, `readonly`,
+`extends`, `impl`, `interface`, `enum`, `match`, `defer`, `spawn`,
+`parallel`, `comptime`, and the rest of the 44-keyword roster.
+Highlight queries (`queries/highlights.scm`), local-scope resolution
+(`queries/locals.scm`), and fold ranges (`queries/folds.scm`) ship as
+companion files.
+
+The keyword roster is drift-guarded against the C lexer by
+`test_grammar_keyword_drift_textmate` and
+`test_grammar_keyword_drift_tree_sitter` invariants — adding a keyword
+to the lexer fails CI until the grammars are updated to match.
+
+## Editor extensions
+
+### VSCode
+
+Search "Iron Language Support" in the Marketplace, or install the
+bundled `iron-lsp-*.vsix` from this release. The extension uses
+`vscode-languageclient` to spawn `ironls` and exposes the standard
+LSP feature set in the editor UI.
+
+Override the `ironls` binary path (e.g. for a locally-built
+development binary) via `iron-lsp.serverPath` in `settings.json`.
+
+### Neovim
+
+Drop the snippet from `editors/neovim/README.md` into your Neovim
+config. The extension uses Neovim's built-in LSP client and a
+filetype plugin to detect `*.iron` files. Override the `ironls`
+binary path by passing `cmd = { "/path/to/ironls" }` when calling
+`vim.lsp.start`.
+
+### Zed
+
+Search "Iron LSP" in Zed's extensions panel. The extension downloads
+`ironls` from the matching release and verifies its SHA-256 before
+spawning. Override the binary path under `lsp."iron-lsp".binary.path`
+in `~/.config/zed/settings.json`.
+
+## Performance budget
+
+- **Cold compile** (full re-lex/re-parse/re-analyze): ~5ms on a
+  500-LOC fixture.
+- **Debounce window**: 250ms per document. A 5-keystroke burst at
+  10ms intervals collapses into one compile.
+- **Cancellation latency**: an in-flight compile observes the cancel
+  flag within ~microseconds on x86_64 and arm64 (memory-order-relaxed
+  atomic load).
+- **Memory growth**: an 8-hour nightly soak gates at < 5 MiB/hr drift
+  and < 800 MiB peak across 28,800 simulated edit events.
+
+There is no incremental parse or analyze yet — every keystroke
+re-runs the full pipeline behind the debounce. The arena-per-compile
+lifetime is friendly to per-file caching above the library surface;
+a future milestone will add it once user-file sizes warrant.
+
+## What's next
+
+- **Inlay hints** (`textDocument/inlayHint`) — type and parameter-name
+  hints inline.
+- **Incremental parse / analyze** — currently a full re-pipeline per
+  keystroke; the arena-per-compile lifetime is friendly to per-file
+  caching above the library surface.
+- **Call hierarchy** — companion to type hierarchy.
+- **Inline values** (debugger integration) — emits last-known values
+  beside the source while debugging.
+- **Workspace-wide refactors** — extract method, inline variable.
+
+## Install
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSfL https://ironlang.dev/install.sh | sh
+```
+
+Pin to a specific version:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSfL https://ironlang.dev/install.sh | sh -s -- --version v3.3.0-alpha
+```
+
+See the [LSP page](https://ironlang.dev/lsp/) for editor setup
+walk-throughs and the [language reference](../language_definition.md)
+for the v3 grammar.


### PR DESCRIPTION
## Summary

Mechanical prep for the next alpha release:

- Bumps `IRON_VERSION_FULL` in `CMakeLists.txt` to the next alpha line.
- Adds `docs/release-notes/<version>.md` covering the editor-support
  delivery: LSP server, tree-sitter grammar, VSCode/Neovim/Zed
  extensions, parity gate, supervisor, soak gate, performance budget.
- Prepends the matching CHANGELOG entry.

No source or test changes.

## Test plan

- [ ] CI green on this branch (build + version-stamp coherence test confirms binaries print the new version)
- [ ] `release.yml` PR-mode artifact build green
- [ ] After merge: tag the release and let `release.yml` publish the artifacts