### PR TITLE
docs(site): remove v3.2.0-alpha release banner

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -851,13 +851,6 @@
   </nav>
   <div class="nav-overlay" id="navOverlay"></div>
 
-  <!-- ── v3.2 release banner ────────────────────────── -->
-  <div class="banner-breaking">
-    <strong>v3.2.0-alpha: Library Authoring Polish.</strong>
-    Ten Forge-filed library-authoring pain points fixed. Doc-test CI now blocks spec-vs-impl drift.
-    <a href="https://github.com/victorl2/iron-lang/blob/main/docs/release-notes/v3.2.md">Release notes</a>
-  </div>
-
   <!-- ── Hero ─────────────────────────────────────────── -->
   <section class="hero">
     <div class="hero-content">


### PR DESCRIPTION
## Summary
- Removes the v3.2.0-alpha "Library Authoring Polish" release banner from the docs site landing page (`docs/site/index.html`).

## Test plan
- [ ] Open `docs/site/index.html` and confirm the banner block above the hero section is gone.
- [ ] Verify hero section still renders correctly without the banner above it.