### PR TITLE
fix(ci): restore macOS networking and VS Code checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,10 +450,15 @@ target_compile_definitions(ironc PRIVATE
 )
 if(OpenSSL_FOUND)
   # The direct-source build path compiles iron_tls.c alongside generated C.
-  # Only enable that backend when the compiler itself was configured against
-  # an available OpenSSL development installation; otherwise user programs
-  # retain plain HTTP/WS and receive the typed TLS_UNAVAILABLE fallback.
-  target_compile_definitions(ironc PRIVATE IRON_CLI_HAVE_OPENSSL=1)
+  # Preserve the exact installation CMake validated. OpenSSL is keg-only on
+  # Homebrew, so plain -lssl/-lcrypto and the compiler default include paths
+  # are insufficient for programs that ironc builds directly.
+  target_compile_definitions(ironc PRIVATE
+      IRON_CLI_HAVE_OPENSSL=1
+      IRON_CLI_OPENSSL_INCLUDE_DIR="${OPENSSL_INCLUDE_DIR}"
+      IRON_CLI_OPENSSL_SSL_LIBRARY="${OPENSSL_SSL_LIBRARY}"
+      IRON_CLI_OPENSSL_CRYPTO_LIBRARY="${OPENSSL_CRYPTO_LIBRARY}"
+  )
 endif()
 
 # ── ironls language server executable (Phase 2 M1 LSP Core) ──────────────────

--- a/editors/vscode/test/runTest.ts
+++ b/editors/vscode/test/runTest.ts
@@ -6,6 +6,11 @@
 import * as path from 'node:path';
 import { runTests } from '@vscode/test-electron';
 
+// VS Code 1.110+ renamed the macOS bundle executable from Electron to Code,
+// while @vscode/test-electron still resolves the old path. Pin the last
+// compatible release line until microsoft/vscode-test#349 is fixed upstream.
+const VSCODE_TEST_VERSION = '1.109.5';
+
 async function main(): Promise<void> {
   // __dirname at runtime = editors/vscode/out/test
   // extensionDevelopmentPath = editors/vscode (contains package.json + dist/)
@@ -20,6 +25,7 @@ async function main(): Promise<void> {
   }
 
   await runTests({
+    version: VSCODE_TEST_VERSION,
     extensionDevelopmentPath,
     extensionTestsPath,
     launchArgs,

--- a/src/cli/build.c
+++ b/src/cli/build.c
@@ -643,6 +643,10 @@ static int build_src_list(const char **argv_buf, int *ai_out,
     argv_buf[ai++] = *sl_websocket_out;
     if (opts.use_tls) {
         argv_buf[ai++] = "/DIRON_HAVE_OPENSSL=1";
+#ifdef IRON_CLI_OPENSSL_INCLUDE_DIR
+        argv_buf[ai++] = "/I";
+        argv_buf[ai++] = IRON_CLI_OPENSSL_INCLUDE_DIR;
+#endif
     }
     argv_buf[ai++] = src_i_flag;
     argv_buf[ai++] = vendor_i_flag;
@@ -662,8 +666,13 @@ static int build_src_list(const char **argv_buf, int *ai_out,
     argv_buf[ai++] = "iphlpapi.lib";
     argv_buf[ai++] = "bcrypt.lib";
     if (opts.use_tls) {
+#ifdef IRON_CLI_OPENSSL_SSL_LIBRARY
+        argv_buf[ai++] = IRON_CLI_OPENSSL_SSL_LIBRARY;
+        argv_buf[ai++] = IRON_CLI_OPENSSL_CRYPTO_LIBRARY;
+#else
         argv_buf[ai++] = "libssl.lib";
         argv_buf[ai++] = "libcrypto.lib";
+#endif
     }
     /* Output flag for clang-cl */
     {
@@ -724,6 +733,10 @@ static int build_src_list(const char **argv_buf, int *ai_out,
     argv_buf[ai++] = *sl_websocket_out;
     if (opts.use_tls) {
         argv_buf[ai++] = "-DIRON_HAVE_OPENSSL=1";
+#ifdef IRON_CLI_OPENSSL_INCLUDE_DIR
+        argv_buf[ai++] = "-I";
+        argv_buf[ai++] = IRON_CLI_OPENSSL_INCLUDE_DIR;
+#endif
     }
     argv_buf[ai++] = src_i_flag;
     argv_buf[ai++] = vendor_i_flag;
@@ -738,8 +751,13 @@ static int build_src_list(const char **argv_buf, int *ai_out,
     argv_buf[ai++] = "-lm";
     argv_buf[ai++] = "-lpthread";
     if (opts.use_tls) {
+#ifdef IRON_CLI_OPENSSL_SSL_LIBRARY
+        argv_buf[ai++] = IRON_CLI_OPENSSL_SSL_LIBRARY;
+        argv_buf[ai++] = IRON_CLI_OPENSSL_CRYPTO_LIBRARY;
+#else
         argv_buf[ai++] = "-lssl";
         argv_buf[ai++] = "-lcrypto";
+#endif
     }
 #endif
 

--- a/src/lir/emit_c.c
+++ b/src/lir/emit_c.c
@@ -5542,7 +5542,8 @@ void emit_instr(Iron_StrBuf *sb, IronLIR_Instr *instr,
              * For non-capturing spawns: arg is the handle itself (self-ref pattern).
              * For capturing spawns (void return): arg is the env struct; use
              *   Iron_handle_create(wrapper, env_arg) for the handle.
-             * For capturing spawns (non-void return): embed result ptr in env struct.
+             * For capturing spawns (non-void return): the wrapper receives the
+             * handle and publishes its result before completion is signalled.
              */
 
             /* Build a deterministic wrapper name */
@@ -5572,33 +5573,24 @@ void emit_instr(Iron_StrBuf *sb, IronLIR_Instr *instr,
 
             /* Emit wrapper into lifted_funcs section */
             iron_strbuf_appendf(&ctx->lifted_funcs,
-                "static void %s(void *_arg) {\n", wrapper_name);
+                has_return && cap_count > 0 && cap_meta && env_type
+                    ? "static void %s(void *_arg, Iron_Handle *_h) {\n"
+                    : "static void %s(void *_arg) {\n",
+                wrapper_name);
 
             if (cap_count > 0 && cap_meta && env_type) {
-                /* Capturing spawn: arg is the env struct.
-                 * For non-void return spawns, embed result in a wrapper struct. */
+                /* Capturing spawn: arg is the env struct. Result-bearing
+                 * wrappers publish through the handle before the runtime
+                 * signals completion, then release the one-shot env. */
                 if (has_return && ret_c) {
-                    /* Build a result-bearing arg struct: { env_t env; ret_t result; } */
-                    Iron_StrBuf rarg_sb = iron_strbuf_create(64);
-                    iron_strbuf_appendf(&rarg_sb, "%s_rarg_t", func_name);
-                    const char *rarg_type = iron_arena_strdup(ctx->arena,
-                        iron_strbuf_get(&rarg_sb), rarg_sb.len);
-                    if (!rarg_type) iron_oom_abort("emit_c.c:emit_instr SPAWN rarg_type");
-                    iron_strbuf_free(&rarg_sb);
-
-                    if (shgeti(ctx->mono_registry, (char *)rarg_type) < 0) {
-                        shput(ctx->mono_registry, (char *)rarg_type, true);
-                        iron_strbuf_appendf(&ctx->struct_bodies,
-                            "typedef struct { %s env; %s result; } %s;\n\n",
-                            env_type, ret_c, rarg_type);
-                    }
-
                     iron_strbuf_appendf(&ctx->lifted_funcs,
-                        "    %s *_ra = (%s *)_arg;\n", rarg_type, rarg_type);
+                        "    %s *_e = (%s *)_arg;\n", env_type, env_type);
                     iron_strbuf_appendf(&ctx->lifted_funcs,
-                        "    %s *_e = &_ra->env;\n", env_type);
+                        "    %s _result = %s(_e);\n", ret_c, c_func_name);
                     iron_strbuf_appendf(&ctx->lifted_funcs,
-                        "    _ra->result = %s(_e);\n", c_func_name);
+                        "    _h->result = (void *)(intptr_t)_result;\n");
+                    iron_strbuf_appendf(&ctx->lifted_funcs,
+                        "    free(_arg);\n");
                 } else {
                     iron_strbuf_appendf(&ctx->lifted_funcs,
                         "    %s *_e = (%s *)_arg;\n", env_type, env_type);
@@ -5645,13 +5637,20 @@ void emit_instr(Iron_StrBuf *sb, IronLIR_Instr *instr,
                     }
                     iron_strbuf_appendf(sb, ";\n");
                 }
-                /* Use Iron_handle_create: wrapper receives env as arg */
+                /* Result wrappers receive both env and handle so the value is
+                 * visible to await before completion is signalled. */
                 emit_indent(sb, ind);
                 iron_strbuf_appendf(sb, "Iron_Handle *");
                 emit_val(sb, instr->id);
-                iron_strbuf_appendf(sb, " = Iron_handle_create("
-                                    "(void (*)(void *))%s, _env_%u);\n",
-                                    wrapper_name, instr->id);
+                if (has_return) {
+                    iron_strbuf_appendf(sb, " = Iron_handle_create_result("
+                                        "(void (*)(void *, Iron_Handle *))%s, _env_%u);\n",
+                                        wrapper_name, instr->id);
+                } else {
+                    iron_strbuf_appendf(sb, " = Iron_handle_create("
+                                        "(void (*)(void *))%s, _env_%u);\n",
+                                        wrapper_name, instr->id);
+                }
             } else {
                 /* Non-capturing handled spawn: use iron_handle_create_self_ref */
                 emit_indent(sb, ind);

--- a/src/runtime/iron_runtime.h
+++ b/src/runtime/iron_runtime.h
@@ -1007,7 +1007,7 @@ void Iron_pool_submit_wait(Iron_Pool *pool,
  * Created by spawn; awaited with Iron_handle_wait().
  * Panic in the spawned task is stored and re-raised on wait.
  */
-typedef struct {
+typedef struct Iron_Handle {
     iron_thread_t   thread;
     bool            done;
     void           *result;
@@ -1018,6 +1018,8 @@ typedef struct {
 
 /* Handle API */
 Iron_Handle *Iron_handle_create(void (*fn)(void *), void *arg);
+Iron_Handle *Iron_handle_create_result(
+    void (*fn)(void *, Iron_Handle *), void *arg);
 void         Iron_handle_wait(Iron_Handle *handle);
 void         Iron_handle_destroy(Iron_Handle *handle);
 void        *iron_future_await(Iron_Handle *handle);

--- a/src/runtime/iron_threads.c
+++ b/src/runtime/iron_threads.c
@@ -672,6 +672,7 @@ void Iron_poolwait_worker_finish(Iron_PoolWait *w,
 typedef struct {
     Iron_Handle *handle;
     void (*fn)(void *);
+    void (*result_fn)(void *, Iron_Handle *);
     void *arg;
 } HandleWrapper;
 
@@ -679,10 +680,12 @@ static void *handle_thread_fn(void *arg) {
     HandleWrapper *w = (HandleWrapper *)arg;
     Iron_Handle *h   = w->handle;
     void (*fn)(void *) = w->fn;
-    void *fn_arg       = w->arg;
+    void (*result_fn)(void *, Iron_Handle *) = w->result_fn;
+    void *fn_arg = w->arg;
     free(w);
 
-    fn(fn_arg);
+    if (result_fn) result_fn(fn_arg, h);
+    else fn(fn_arg);
 
     IRON_MUTEX_LOCK(h->lock);
     h->done = true;
@@ -706,11 +709,41 @@ Iron_Handle *Iron_handle_create(void (*fn)(void *), void *arg) {
     if (!w) iron_oom_abort("iron_threads.c:Iron_handle_create wrapper");
     w->handle = h;
     w->fn     = fn;
+    w->result_fn = NULL;
     w->arg    = arg;
 
     /* FIX-02: IRON_THREAD_CREATE failure → iron_oom_abort (AUDIT-03 §32). */
     if (IRON_THREAD_CREATE(h->thread, handle_thread_fn, w) != 0) {
         iron_oom_abort("iron_threads.c:Iron_handle_create IRON_THREAD_CREATE");
+    }
+    return h;
+}
+
+Iron_Handle *Iron_handle_create_result(
+    void (*fn)(void *, Iron_Handle *), void *arg) {
+    /* Result-bearing captured spawns need the handle while their generated
+     * wrapper is running so they can publish the value before completion is
+     * signalled. Construct the handle and wrapper fully before starting the
+     * thread; handle_thread_fn provides the synchronization edge. */
+    Iron_Handle *h = (Iron_Handle *)malloc(sizeof(Iron_Handle));
+    if (!h) iron_oom_abort("iron_threads.c:Iron_handle_create_result handle");
+
+    h->done      = false;
+    h->result    = NULL;
+    h->panic_msg = NULL;
+    IRON_MUTEX_INIT(h->lock);
+    IRON_COND_INIT(h->cond);
+
+    HandleWrapper *w = (HandleWrapper *)malloc(sizeof(HandleWrapper));
+    if (!w) iron_oom_abort("iron_threads.c:Iron_handle_create_result wrapper");
+    w->handle    = h;
+    w->fn        = NULL;
+    w->result_fn = fn;
+    w->arg       = arg;
+
+    if (IRON_THREAD_CREATE(h->thread, handle_thread_fn, w) != 0) {
+        iron_oom_abort(
+            "iron_threads.c:Iron_handle_create_result IRON_THREAD_CREATE");
     }
     return h;
 }
@@ -763,6 +796,7 @@ Iron_Handle *iron_handle_create_self_ref(void (*fn)(void *)) {
     if (!w) iron_oom_abort("iron_threads.c:iron_handle_create_self_ref wrapper");
     w->handle = h;
     w->fn     = fn;
+    w->result_fn = NULL;
     w->arg    = h;  /* self-referential: pass handle as arg */
 
     /* FIX-02: IRON_THREAD_CREATE failure → iron_oom_abort (AUDIT-03 §32). */

--- a/tests/integration/v4/7.5-stdlib/http_concurrency.iron
+++ b/tests/integration/v4/7.5-stdlib/http_concurrency.iron
@@ -13,15 +13,16 @@ func serve_one(server: HttpServer) -> Int {
     val response = Http.json_response(200, "\{\"status\":\"ok\"\}")
     val sent = HttpConnection.send_response(accepted.connection, response, 5000)
     HttpConnection.close(accepted.connection)
-    return sent
+    if sent != 0 { return sent }
+    return 1
 }
 
-func fetch_one(url: String) -> Int {
+func fetch_one(url: String, result: Int) -> Int {
     val response = Http.get(url, 10000)
     if response.error != 0 { return response.error }
     if response.status != 200 { return -1 }
     if response.body != "\{\"status\":\"ok\"\}" { return -2 }
-    return 0
+    return result
 }
 
 func main() {
@@ -42,21 +43,23 @@ func main() {
     val s7 = spawn("server-7") { return serve_one(listening.server) }
     val s8 = spawn("server-8") { return serve_one(listening.server) }
 
-    val c1 = spawn("client-1") { return fetch_one(url) }
-    val c2 = spawn("client-2") { return fetch_one(url) }
-    val c3 = spawn("client-3") { return fetch_one(url) }
-    val c4 = spawn("client-4") { return fetch_one(url) }
-    val c5 = spawn("client-5") { return fetch_one(url) }
-    val c6 = spawn("client-6") { return fetch_one(url) }
-    val c7 = spawn("client-7") { return fetch_one(url) }
-    val c8 = spawn("client-8") { return fetch_one(url) }
+    -- Distinct non-zero results make this an await-value test as well as a
+    -- networking test; a dropped result can no longer look like success.
+    val c1 = spawn("client-1") { return fetch_one(url, 1) }
+    val c2 = spawn("client-2") { return fetch_one(url, 2) }
+    val c3 = spawn("client-3") { return fetch_one(url, 3) }
+    val c4 = spawn("client-4") { return fetch_one(url, 4) }
+    val c5 = spawn("client-5") { return fetch_one(url, 5) }
+    val c6 = spawn("client-6") { return fetch_one(url, 6) }
+    val c7 = spawn("client-7") { return fetch_one(url, 7) }
+    val c8 = spawn("client-8") { return fetch_one(url, 8) }
 
     val cr = (await c1) + (await c2) + (await c3) + (await c4) +
              (await c5) + (await c6) + (await c7) + (await c8)
     val sr = (await s1) + (await s2) + (await s3) + (await s4) +
              (await s5) + (await s6) + (await s7) + (await s8)
     HttpServer.close(listening.server)
-    if cr == 0 and sr == 0 {
+    if cr == 36 and sr == 8 {
         println("http concurrency ok: 8 clients")
     } else {
         println("http concurrency failed: clients={cr} servers={sr}")


### PR DESCRIPTION
## Summary

This patch unblocks the two failing macOS checks on #95 and fixes the concurrency defect that the original OpenSSL compile failure was masking.

- propagate the exact OpenSSL include directory and SSL/Crypto library paths detected by CMake into programs compiled directly by ironc
- pin the VS Code Electron E2E runtime to 1.109.5, the last compatible release before the macOS bundle executable rename tracked by microsoft/vscode-test#349
- repair captured, result-bearing spawn codegen so it no longer writes beyond its allocated capture environment
- publish captured task results through Iron_Handle before completion is signalled, and free the one-shot capture environment
- strengthen the HTTP concurrency acceptance fixture with distinct non-zero results from all 16 tasks so discarded await values cannot pass accidentally

This PR intentionally targets feat/networking-https-websocket-files so it can be merged into #95 without pulling the feature branch into main independently.

## Root causes

### macOS networking compile failure

CMake successfully found Homebrew OpenSSL, but ironc starts a separate Clang process for generated programs. That process only received IRON_HAVE_OPENSSL plus -lssl and -lcrypto. Homebrew OpenSSL is keg-only, so Clang could not find openssl/err.h from its default search paths.

The compiler now receives CMake's validated OPENSSL_INCLUDE_DIR, OPENSSL_SSL_LIBRARY, and OPENSSL_CRYPTO_LIBRARY values and forwards those exact paths to its child Clang invocation. The existing fallback remains for builds that define only IRON_CLI_HAVE_OPENSSL.

### VS Code E2E launch failure

@vscode/test-electron 2.5.2 still resolves the macOS executable as Contents/MacOS/Electron. VS Code 1.110 and later renamed that executable to Code, so automatically selecting the newest version downloaded a valid bundle and then tried to launch a path that no longer exists.

The harness now requests VS Code 1.109.5 explicitly. This keeps the existing dependency and extension engine range unchanged while avoiding the upstream incompatibility: https://github.com/microsoft/vscode-test/issues/349

### Captured spawn heap corruption

For a captured spawn returning a value, generated C declared a larger result-bearing structure but allocated only the smaller environment:

```c
typedef struct { capture_env env; int64_t result; } result_arg;
capture_env *arg = malloc(sizeof(capture_env));
((result_arg *)arg)->result = worker(&((result_arg *)arg)->env);
```

That result write landed immediately past the allocation. On macOS the HTTP concurrency fixture intermittently failed later inside malloc/free with SIGTRAP or SIGSEGV, including during HTTP body allocation, string interning, and pool teardown. Await also read Iron_Handle.result, which the captured wrapper never populated; a successful networking result of zero hid that second defect.

Generated captured-result wrappers now receive their Iron_Handle from the runtime, store the result before the runtime signals done, and free the correctly sized environment:

```c
static void wrapper(void *arg, Iron_Handle *handle) {
    capture_env *env = arg;
    int64_t result = worker(env);
    handle->result = (void *)(intptr_t)result;
    free(arg);
}
```

## Validation

- full v4 acceptance corpus: 379 fixtures passed (611.56 s)
- HTTP Iron concurrency acceptance: 20 consecutive macOS runs passed
- WebSocket Iron roundtrip acceptance: 20 consecutive macOS runs passed
- AddressSanitizer + UndefinedBehaviorSanitizer HTTP concurrency binary: passed with no invalid access
- runtime threads, HTTP, WebSocket, HTTPS/WSS unit tests: passed
- regular and binary file-operation Iron roundtrip: passed
- HTTP webpage example compile check: passed
- VS Code extension TypeScript compile, prepackage, bundle, and E2E test: passed
- VS Code 1.109.5 darwin-arm64 bundle downloaded and launched; live ironls diagnostic assertion passed
- git diff --check: passed

Unblocks #95.
