### PR TITLE
fix(io): make no-overwrite moves atomic

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -199,6 +199,13 @@ Available result-returning operations are `read_text`, `read_bytes`,
 limit before allocating. Writes report the committed byte count and surface
 open, write, flush, and close errors. Copy/move take an explicit `overwrite`
 flag. See [file_operations.iron](../examples/networking/file_operations.iron).
+With `overwrite=false`, move commits the destination atomically: if another
+task or process creates that path first, the move returns
+`IRON_ERR_IO_ALREADY_EXISTS` and preserves both the source and the winning
+destination. POSIX filesystems use an atomic hard-link commit (including after
+a cross-device temporary copy); Windows uses `MoveFileEx` without replacement.
+Filesystems that cannot provide that primitive return an error instead of
+falling back to a racy check-then-rename.
 
 ## Framing and limits
 

--- a/docs/site/networking/index.html
+++ b/docs/site/networking/index.html
@@ -459,7 +459,7 @@
 <span class="kw">val</span> appended = <span class="ty">IO</span>.<span class="fn">append_bytes</span>(<span class="st">"asset.bin"</span>, <span class="st">"\0suffix"</span>)
 <span class="kw">val</span> copied = <span class="ty">IO</span>.<span class="fn">copy_file</span>(<span class="st">"asset.bin"</span>, <span class="st">"asset-copy.bin"</span>, <span class="kw">false</span>)
 <span class="kw">val</span> moved = <span class="ty">IO</span>.<span class="fn">move_file</span>(<span class="st">"asset-copy.bin"</span>, <span class="st">"archive.bin"</span>, <span class="kw">false</span>)</code></pre></div>
-      <p><code>read_text</code> and <code>read_bytes</code> reject an oversized file before allocating. Write and append operations report committed bytes and expose open, write, flush, and close failures. <code>copy_file</code> and <code>move_file</code> require an explicit overwrite choice.</p>
+      <p><code>read_text</code> and <code>read_bytes</code> reject an oversized file before allocating. Write and append operations report committed bytes and expose open, write, flush, and close failures. <code>copy_file</code> and <code>move_file</code> require an explicit overwrite choice. With <code>overwrite=false</code>, move uses an atomic no-replace commit: a concurrently created destination wins intact and the source remains. Unsupported filesystems return an error instead of using a racy check-then-rename.</p>
 
       <h2 id="websocket">WebSocket and secure WebSocket</h2>
       <p><code>import websocket</code> supports RFC 6455 clients and HTTP/HTTPS server upgrades. WSS uses the same verified TLS policy as HTTPS.</p>

--- a/src/stdlib/io.iron
+++ b/src/stdlib/io.iron
@@ -51,4 +51,7 @@ func IO.append_text(path: String, content: String) -> FileWriteResult {}
 func IO.append_bytes(path: String, content: String) -> FileWriteResult {}
 func IO.file_info(path: String) -> FileInfo {}
 func IO.copy_file(source: String, destination: String, overwrite: Bool) -> FileWriteResult {}
+-- With overwrite=false, destination creation is atomic: a concurrently
+-- created destination is never replaced. Cross-device moves publish only a
+-- complete copy before removing the source.
 func IO.move_file(source: String, destination: String, overwrite: Bool) -> FileWriteResult {}

--- a/src/stdlib/iron_io.c
+++ b/src/stdlib/iron_io.c
@@ -7,6 +7,12 @@
 #include <sys/stat.h>
 #include <dirent.h>  /* WINDOWS-TODO: no dirent.h on Windows — use FindFirstFile/FindNextFile/FindClose from <windows.h> */
 #include <errno.h>
+#ifdef _WIN32
+#include <windows.h>
+#endif
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 /* ── File I/O ────────────────────────────────────────────────────────────── */
 
@@ -604,31 +610,149 @@ Iron_FileWriteResult Iron_io_move_file(Iron_String source,
             return io_write_result(0, IRON_ERR_IO_ALREADY_EXISTS);
         }
     }
-#ifdef _WIN32
-    if (overwrite) remove(destination_text);
-#endif
-    if (rename(source_text, destination_text) == 0) {
+#ifndef _WIN32
+    /* POSIX rename(2) always replaces an existing destination.  For the
+     * no-overwrite contract, link(2) is the portable atomic create-if-absent
+     * primitive: either our source inode becomes the destination, or a racing
+     * creator wins and link reports EEXIST.  Unlinking the old name completes
+     * the move without opening a stat/rename race. */
+    int move_result = overwrite
+        ? rename(source_text, destination_text)
+        : link(source_text, destination_text);
+    if (move_result == 0) {
+        if (!overwrite && unlink(source_text) != 0) {
+            /* Both names still refer to the same inode.  Do not remove the
+             * successfully committed destination: callers can safely retry
+             * cleanup of the source and no data has been lost. */
+            free(source_text);
+            free(destination_text);
+            return io_write_result((int64_t)source_info.st_size,
+                                   IRON_ERR_IO_WRITE);
+        }
         int64_t size = (int64_t)source_info.st_size;
         free(source_text);
         free(destination_text);
         return io_write_result(size, 0);
     }
     int rename_error = errno;
-    free(source_text);
-    free(destination_text);
 #ifdef EXDEV
     if (rename_error == EXDEV) {
-        Iron_FileWriteResult copied = Iron_io_copy_file(
-            source, destination, overwrite);
-        if (copied.error != 0) return copied;
-        char *source_again = NULL;
-        if (io_path_copy(source, &source_again) <= 0 || remove(source_again) != 0) {
+        if (overwrite) {
+            free(source_text);
+            free(destination_text);
+            Iron_FileWriteResult copied = Iron_io_copy_file(
+                source, destination, true);
+            if (copied.error != 0) return copied;
+            char *source_again = NULL;
+            if (io_path_copy(source, &source_again) <= 0 ||
+                remove(source_again) != 0) {
+                free(source_again);
+                return io_write_result(copied.bytes, IRON_ERR_IO_WRITE);
+            }
             free(source_again);
-            return io_write_result(copied.bytes, IRON_ERR_IO_WRITE);
+            return copied;
         }
-        free(source_again);
-        return copied;
+
+        /* A cross-device no-overwrite move must not expose a partial target or
+         * let a racing creator be replaced.  Copy to an exclusive temporary
+         * file in the destination filesystem, flush it, then atomically link
+         * that complete file into the requested name. */
+        size_t destination_length = strlen(destination_text);
+        static const char suffix[] = ".iron-move-XXXXXX";
+        char *temporary = (char *)malloc(destination_length + sizeof(suffix));
+        if (!temporary) {
+            free(source_text);
+            free(destination_text);
+            return io_write_result(0, IRON_ERR_IO_NO_MEMORY);
+        }
+        memcpy(temporary, destination_text, destination_length);
+        memcpy(temporary + destination_length, suffix, sizeof(suffix));
+        int temporary_fd = mkstemp(temporary);
+        if (temporary_fd < 0) {
+            int temporary_error = errno;
+            free(temporary);
+            free(source_text);
+            free(destination_text);
+            return io_write_result(0, io_error_from_errno(temporary_error));
+        }
+        (void)fchmod(temporary_fd, source_info.st_mode & 0777);
+        FILE *input = fopen(source_text, "rb");
+        FILE *output = fdopen(temporary_fd, "wb");
+        int64_t total = 0;
+        int failed = !input || !output;
+        if (!output) close(temporary_fd);
+        uint8_t buffer[64 * 1024];
+        while (!failed) {
+            size_t received = fread(buffer, 1, sizeof(buffer), input);
+            if (received == 0) {
+                if (ferror(input)) failed = 1;
+                break;
+            }
+            size_t written = 0;
+            while (written < received) {
+                size_t count = fwrite(buffer + written, 1,
+                                      received - written, output);
+                if (count == 0) { failed = 1; break; }
+                written += count;
+                total += (int64_t)count;
+            }
+        }
+        if (output && (fflush(output) != 0 || fsync(fileno(output)) != 0)) {
+            failed = 1;
+        }
+        if (input && fclose(input) != 0) failed = 1;
+        if (output && fclose(output) != 0) failed = 1;
+        if (failed) {
+            unlink(temporary);
+            free(temporary);
+            free(source_text);
+            free(destination_text);
+            return io_write_result(total, IRON_ERR_IO_WRITE);
+        }
+        if (link(temporary, destination_text) != 0) {
+            int commit_error = errno;
+            unlink(temporary);
+            free(temporary);
+            free(source_text);
+            free(destination_text);
+            return io_write_result(0, io_error_from_errno(commit_error));
+        }
+        unlink(temporary);
+        free(temporary);
+        if (unlink(source_text) != 0) {
+            free(source_text);
+            free(destination_text);
+            return io_write_result(total, IRON_ERR_IO_WRITE);
+        }
+        free(source_text);
+        free(destination_text);
+        return io_write_result(total, 0);
     }
 #endif
+    free(source_text);
+    free(destination_text);
     return io_write_result(0, io_error_from_errno(rename_error));
+#else
+    /* MoveFileEx without MOVEFILE_REPLACE_EXISTING is Windows' atomic
+     * no-replace primitive.  MOVEFILE_COPY_ALLOWED supplies the cross-volume
+     * fallback while retaining the same destination-exists contract. */
+    DWORD flags = MOVEFILE_COPY_ALLOWED;
+    if (overwrite) flags |= MOVEFILE_REPLACE_EXISTING;
+    if (MoveFileExA(source_text, destination_text, flags)) {
+        int64_t size = (int64_t)source_info.st_size;
+        free(source_text);
+        free(destination_text);
+        return io_write_result(size, 0);
+    }
+    DWORD move_error = GetLastError();
+    free(source_text);
+    free(destination_text);
+    if (move_error == ERROR_ALREADY_EXISTS || move_error == ERROR_FILE_EXISTS) {
+        return io_write_result(0, IRON_ERR_IO_ALREADY_EXISTS);
+    }
+    if (move_error == ERROR_ACCESS_DENIED) {
+        return io_write_result(0, IRON_ERR_IO_PERMISSION);
+    }
+    return io_write_result(0, IRON_ERR_IO_OTHER);
+#endif
 }

--- a/tests/lsp/unit/test_lsp_diagnostic_debounce.c
+++ b/tests/lsp/unit/test_lsp_diagnostic_debounce.c
@@ -5,7 +5,8 @@
  *
  *   1. Rapid COMPILE posts (< 50ms apart) trigger exactly one call into
  *      the facade (coalescing + debounce).
- *   2. A COMPILE post 300ms AFTER another COMPILE triggers two calls.
+ *   2. A COMPILE posted after the previous debounced call completes
+ *      triggers a second call.
  *
  * The test provides its own definitions of ilsp_facade_compile and
  * ilsp_facade_pull_diagnostic as link-time stubs (CMake is configured
@@ -69,6 +70,15 @@ static void sleep_ms(int ms) {
     nanosleep(&req, NULL);
 }
 
+static bool wait_for_compile_calls(int expected, int timeout_ms) {
+    uint64_t deadline = now_ms() + (uint64_t)timeout_ms;
+    while (atomic_load(&g_facade_compile_calls) < expected) {
+        if (now_ms() >= deadline) return false;
+        sleep_ms(5);
+    }
+    return true;
+}
+
 /* Minimal fake document + server. The worker touches doc->mailbox,
  * doc->abort_jmp, doc->abort_count, doc->quarantined, doc->shutdown,
  * doc->uri. Nothing else needs to be wired. */
@@ -106,9 +116,13 @@ static void test_rapid_compiles_coalesce_to_one_call(void) {
         sleep_ms(10);  /* 10ms gap between posts */
     }
 
-    /* Wait out the debounce + slack. After 500ms, the worker has had
-     * 250ms of idle to run exactly one compile. */
-    sleep_ms(500);
+    /* Wait for the worker instead of assuming the CI host schedules it
+     * within a fixed wall-clock interval. Once the call arrives, a full
+     * debounce window without another call proves that the burst stayed
+     * coalesced. */
+    TEST_ASSERT_TRUE_MESSAGE(wait_for_compile_calls(1, 2000),
+        "rapid-burst COMPILE did not run before the test deadline");
+    sleep_ms(300);
 
     int calls = atomic_load(&g_facade_compile_calls);
     int32_t v = atomic_load(&g_last_compile_version);
@@ -121,7 +135,7 @@ static void test_rapid_compiles_coalesce_to_one_call(void) {
     destroy_doc(doc);
 }
 
-/* ── Test 2: COMPILE, sleep 350ms, COMPILE -> 2 facade calls ────────── */
+/* ── Test 2: completed COMPILE, then COMPILE -> 2 facade calls ─────── */
 static void test_spaced_compiles_trigger_two_calls(void) {
     atomic_store(&g_facade_compile_calls, 0);
 
@@ -132,11 +146,12 @@ static void test_spaced_compiles_trigger_two_calls(void) {
     TEST_ASSERT_TRUE(ilsp_ast_worker_start(&server, doc));
 
     ilsp_mailbox_post_compile(doc->mailbox, 1, NULL);
-    /* Wait out the first compile's debounce + slack. */
-    sleep_ms(350);
+    TEST_ASSERT_TRUE_MESSAGE(wait_for_compile_calls(1, 2000),
+        "first spaced COMPILE did not run before the test deadline");
 
     ilsp_mailbox_post_compile(doc->mailbox, 2, NULL);
-    sleep_ms(350);
+    TEST_ASSERT_TRUE_MESSAGE(wait_for_compile_calls(2, 2000),
+        "second spaced COMPILE did not run before the test deadline");
 
     int calls = atomic_load(&g_facade_compile_calls);
     TEST_ASSERT_EQUAL_INT_MESSAGE(2, calls,
@@ -169,15 +184,14 @@ static void test_debounce_observes_250ms(void) {
     }
     uint64_t observed = now_ms() - t0;
 
-    /* Debounce is 250ms nominal. The original tolerance was +/-100ms
-     * (150-350ms window), but GitHub-hosted macos-latest runners
-     * regularly observe 350-450ms wall-clock for the same workload due
-     * to shared-host scheduling jitter. Widen tolerance to +/-250ms
-     * (window 0-500ms) — still tight enough to catch a missing debounce
-     * (would be ~5ms) but loose enough not to flake on noisy CI. */
-    TEST_ASSERT_INT_WITHIN_MESSAGE(250 /*+- tol*/, 250 /*target*/,
-                                    (int)observed,
-        "observed debounce deviates from 250ms beyond +-250ms tolerance");
+    /* Scheduling can delay a worker on a shared CI host, but it cannot
+     * legitimately make the 250ms debounce expire early. Keep a strict
+     * lower bound to catch a missing debounce and a generous upper bound
+     * that matches the explicit test deadline. */
+    TEST_ASSERT_GREATER_OR_EQUAL_INT_MESSAGE(200, (int)observed,
+        "observed debounce expired too early");
+    TEST_ASSERT_LESS_OR_EQUAL_INT_MESSAGE(2000, (int)observed,
+        "observed debounce exceeded the test deadline");
     (void)elapsed;
 
     ilsp_ast_worker_shutdown_and_join(doc);

--- a/tests/unit/test_cov_stdlib_io.c
+++ b/tests/unit/test_cov_stdlib_io.c
@@ -35,6 +35,8 @@
 #include "unity.h"
 
 #include <errno.h>
+#include <stdatomic.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -71,7 +73,7 @@ static void sandbox_nuke(void) {
     const char *names[] = {
         "a.txt", "b.txt", "c.txt", "hello.txt", "lines.txt", "append.txt",
         "bytes.bin", "bounded.bin", "copied.bin", "moved.bin", "written.txt",
-        "nope.txt", NULL
+        "nope.txt", "race-source.bin", "race-target.bin", NULL
     };
     for (int i = 0; names[i]; i++) {
         snprintf(path, sizeof(path), "%s/%s", s_sandbox, names[i]);
@@ -392,6 +394,83 @@ void test_io_text_append_info_copy_move(void) {
     TEST_ASSERT_TRUE(Iron_io_file_info(moved_path).exists);
 }
 
+typedef struct MoveRaceArgs {
+    Iron_String source;
+    Iron_String destination;
+    atomic_bool *start;
+    Iron_FileWriteResult moved;
+    int create_error;
+} MoveRaceArgs;
+
+static void *move_race_mover(void *opaque) {
+    MoveRaceArgs *args = (MoveRaceArgs *)opaque;
+    while (!atomic_load_explicit(args->start, memory_order_acquire)) { }
+    args->moved = Iron_io_move_file(args->source, args->destination, false);
+    return NULL;
+}
+
+static void *move_race_creator(void *opaque) {
+    MoveRaceArgs *args = (MoveRaceArgs *)opaque;
+    while (!atomic_load_explicit(args->start, memory_order_acquire)) { }
+    const char winner[] = "creator";
+    FILE *file = fopen(iron_string_cstr(&args->destination), "wbx");
+    if (!file) {
+        args->create_error = errno;
+        return NULL;
+    }
+    size_t written = fwrite(winner, 1, sizeof(winner) - 1, file);
+    int close_error = fclose(file);
+    args->create_error = written == sizeof(winner) - 1 && close_error == 0
+        ? 0 : EIO;
+    return NULL;
+}
+
+void test_io_no_overwrite_move_is_atomic_against_creator(void) {
+    Iron_String source = mkpath("race-source.bin");
+    Iron_String destination = mkpath("race-target.bin");
+
+    for (int round = 0; round < 500; round++) {
+        unlink(iron_string_cstr(&source));
+        unlink(iron_string_cstr(&destination));
+        Iron_FileWriteResult seeded = Iron_io_write_bytes(
+            source, make_str("source"));
+        TEST_ASSERT_EQUAL_INT64(0, seeded.error);
+
+        atomic_bool start;
+        atomic_init(&start, false);
+        MoveRaceArgs args = {
+            .source = source,
+            .destination = destination,
+            .start = &start,
+            .moved = {0},
+            .create_error = -1,
+        };
+        pthread_t mover;
+        pthread_t creator;
+        TEST_ASSERT_EQUAL_INT(0, pthread_create(&mover, NULL,
+                                                move_race_mover, &args));
+        TEST_ASSERT_EQUAL_INT(0, pthread_create(&creator, NULL,
+                                                move_race_creator, &args));
+        atomic_store_explicit(&start, true, memory_order_release);
+        TEST_ASSERT_EQUAL_INT(0, pthread_join(mover, NULL));
+        TEST_ASSERT_EQUAL_INT(0, pthread_join(creator, NULL));
+
+        Iron_FileReadResult final = Iron_io_read_bytes(destination, 16);
+        TEST_ASSERT_EQUAL_INT64(0, final.error);
+        if (args.moved.error == 0) {
+            TEST_ASSERT_EQUAL_INT(EEXIST, args.create_error);
+            TEST_ASSERT_EQUAL_STRING("source", iron_string_cstr(&final.data));
+            TEST_ASSERT_FALSE(Iron_io_file_info(source).exists);
+        } else {
+            TEST_ASSERT_EQUAL_INT64(IRON_ERR_IO_ALREADY_EXISTS,
+                                    args.moved.error);
+            TEST_ASSERT_EQUAL_INT(0, args.create_error);
+            TEST_ASSERT_EQUAL_STRING("creator", iron_string_cstr(&final.data));
+            TEST_ASSERT_TRUE(Iron_io_file_info(source).exists);
+        }
+    }
+}
+
 /* ── main ────────────────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -410,5 +489,6 @@ int main(void) {
     RUN_TEST(test_io_read_lines);
     RUN_TEST(test_io_bounded_binary_roundtrip);
     RUN_TEST(test_io_text_append_info_copy_move);
+    RUN_TEST(test_io_no_overwrite_move_is_atomic_against_creator);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Fixes #93 by removing the `stat`/`rename` race from `IO.move_file(..., false)`.

- Uses an atomic hard-link commit on POSIX so a concurrent destination creator can never be replaced.
- Uses a complete, flushed temporary file plus atomic no-replace publication for cross-device moves.
- Uses `MoveFileEx` without `MOVEFILE_REPLACE_EXISTING` on Windows.
- Preserves the source whenever another creator wins.
- Documents the exact guarantee and behavior on filesystems without the required primitive.

## Why the old implementation was unsafe

The old flow checked `stat(destination)` and then called `rename(source, destination)`. POSIX `rename` replaces an existing destination, so another task or process could create the file between those calls and lose its contents even though `overwrite` was false.

## CI reliability follow-up

The first macOS CI run exposed an unrelated flaky LSP debounce test. It assumed a worker would be scheduled within two fixed 350 ms sleeps; on a loaded runner the second post occurred before the first debounced call, so the expected count of two was incorrectly one.

The test now waits for each observable facade call with a bounded 2-second deadline. It still enforces a strict 200 ms lower bound for the 250 ms debounce, so a missing debounce cannot pass, while host scheduling delays no longer change the semantic sequence under test.

## Validation

- `cmake --build build --target test_cov_stdlib_io -j4`
- `ctest --test-dir build -R '^test_cov_stdlib_io$' --output-on-failure`
- New 500-round two-thread race test: exactly one of exclusive destination creation or no-overwrite move wins; final bytes and source preservation are checked for both outcomes.
- Updated debounce test passed **100/100** iterations in the canonical `silvaserver.local` Linux container.
- Full local non-benchmark suite passed: **495 runnable tests**, 0 failures.
- `git diff --check`
