### PR TITLE
fix(stdlib): make networking models leak-clean and portable

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -21,6 +21,33 @@ header parsing, and body/frame decoding. Transport errors use codes
 `1000..1999`, TLS uses `3000..3099`, HTTP uses `5000..5099`, WebSocket uses
 `6000..6099`, and file I/O uses `8000..8099`.
 
+## Result ownership
+
+HTTP, WebSocket, and explicit file operations return model values that own
+their string fields. Consume those strings with the matching `release` call
+after the last read, on both success and error paths:
+
+- `HttpServerResult.release`, `HttpConnectionResult.release`,
+  `HttpsServerResult.release`, `HttpsConnectionResult.release`,
+  `HttpsPendingConnectionResult.release`, and `HttpClientResult.release`
+- `HttpRequest.release` and `HttpResponse.release`
+- `WebSocketResult.release` and `WebSocketMessage.release`
+- `FileReadResult.release`, `FileWriteResult.release`, and `FileInfo.release`
+
+Resource handles have a separate lifetime: close or transfer the server,
+connection, client, or socket first, then release its result model. Response
+constructors clone their header and body inputs, so releasing a response never
+invalidates the caller's strings. `Http.header` and other standalone dynamic
+strings can be consumed with `value.release()`.
+
+Release is consuming. Iron strings and models are value types, so do not use a
+released value or a by-value alias afterwards. Inline strings and interned
+literals are safe no-ops. C callers use `iron_string_release` and the
+`Iron_*_release` functions declared in the corresponding public headers; the
+same no-alias-after-release rule applies. Low-level `iron_tls.h` result structs
+contain only resource handles and numeric `Iron_NetError` values, so they own
+no strings and need no result release; close or free any successful handle.
+
 ## Client
 
 ```iron
@@ -30,10 +57,11 @@ func main() {
     val response = Http.get("http://127.0.0.1:8080/api/status", 5000)
     if response.error != 0 {
         println("request failed: {response.error} {response.error_message}")
-        return
+    } else {
+        println("status={response.status}")
+        println(response.body)
     }
-    println("status={response.status}")
-    println(response.body)
+    HttpResponse.release(response)
 }
 ```
 
@@ -132,13 +160,20 @@ Production HTTPS and WSS accept loops should separate TCP admission from TLS:
 ```iron
 val pending = HttpsServer.accept_tcp(server, 60000)
 if pending.error == 0 {
+    val connection = pending.connection
+    HttpsPendingConnectionResult.release(pending)
     spawn("tls-client") {
-        val secure = HttpsPendingConnection.handshake(pending.connection, 5000)
-        if secure.error != 0 { return secure.error }
-        -- read HTTP or upgrade to WebSocket here
-        HttpsConnection.close(secure.connection)
-        return 0
+        val secure = HttpsPendingConnection.handshake(connection, 5000)
+        val outcome = secure.error
+        if secure.error == 0 {
+            -- read HTTP or upgrade to WebSocket here
+            HttpsConnection.close(secure.connection)
+        }
+        HttpsConnectionResult.release(secure)
+        return outcome
     }
+} else {
+    HttpsPendingConnectionResult.release(pending)
 }
 ```
 
@@ -171,14 +206,16 @@ val connected = WebSocket.connect(
     1048576,
     5000,
 )
-if connected.error != 0 { return }
-
-val sent = WebSocket.send_text(connected.socket, "subscribe", 5000)
-val message = WebSocket.receive(connected.socket, 30000)
-if message.error == 0 and message.kind == 1 {
-    println(message.data)
+if connected.error == 0 {
+    val sent = WebSocket.send_text(connected.socket, "subscribe", 5000)
+    val message = WebSocket.receive(connected.socket, 30000)
+    if message.error == 0 and message.kind == 1 {
+        println(message.data)
+    }
+    val closed = WebSocket.close(connected.socket, 1000, "done", 5000)
+    WebSocketMessage.release(message)
 }
-val closed = WebSocket.close(connected.socket, 1000, "done", 5000)
+WebSocketResult.release(connected)
 ```
 
 Use `connect_with_ca` for a private root. The explicitly named
@@ -234,14 +271,20 @@ import io
 
 val written = IO.write_bytes("asset.bin", "Iron\0binary")
 val loaded = IO.read_bytes("asset.bin", 1048576)
+val info = IO.file_info("asset.bin")
 if loaded.error == 0 {
-    val info = IO.file_info("asset.bin")
     println("loaded {info.size} bytes")
 }
 
 val appended = IO.append_bytes("asset.bin", "\0suffix")
 val copied = IO.copy_file("asset.bin", "asset-copy.bin", false)
 val moved = IO.move_file("asset-copy.bin", "archive.bin", false)
+FileWriteResult.release(written)
+FileReadResult.release(loaded)
+FileInfo.release(info)
+FileWriteResult.release(appended)
+FileWriteResult.release(copied)
+FileWriteResult.release(moved)
 ```
 
 Available result-returning operations are `read_text`, `read_bytes`,
@@ -267,13 +310,19 @@ owns a bounded pool:
 ```iron
 val opened = HttpClient.open(
     "https://api.example.com", "", false, 4, 30000)
-if opened.error != 0 { return }
+if opened.error != 0 {
+    HttpClientResult.release(opened)
+    return
+}
 
 val first = HttpClient.request(
     opened.client, "GET", "/api/status", "", "", 1048576, 5000)
 val second = HttpClient.request(
     opened.client, "GET", "/api/items", "", "", 1048576, 5000)
 HttpClient.close(opened.client)
+HttpResponse.release(first)
+HttpResponse.release(second)
+HttpClientResult.release(opened)
 ```
 
 The origin fixes scheme, host, port, certificate roots, and verification mode;
@@ -297,11 +346,14 @@ while running and served < 100 {
     if request.error == 0 {
         served += 1
         val keep = request.keep_alive and served < 100
+        val response = Http.text_response(200, "ok")
         val sent = HttpConnection.send_response_keep_alive(
-            connection, Http.text_response(200, "ok"), keep, 5000)
+            connection, response, keep, 5000)
+        HttpResponse.release(response)
         if sent != 0 { running = false }
         if sent == 0 { running = keep }
     }
+    HttpRequest.release(request)
 }
 HttpConnection.close(connection)
 ```
@@ -391,17 +443,11 @@ The reproducible remote image can be rebuilt with
 `podman build -f tools/containers/iron-lsp-build.Containerfile -t localhost/iron-lsp-build:latest .`.
 In that image, the focused runtime-thread, HTTP, HTTPS/TLS, WebSocket/WSS,
 concurrent Iron client/server, and text/binary-file battery passed 8/8 under
-ASan/UBSan and 8/8 under TSan. All eight practical networking examples also
-passed `ironc check` and native Release compilation. Leak detection is tracked
-separately below because it currently reports process-lifetime and C-fixture
-allocations before some generated integration programs can run.
+ASan/UBSan with LeakSanitizer enabled and 8/8 under TSan. All eight practical
+networking examples also passed `ironc check` and native Release compilation.
 
 ## Known gaps
 
-- The focused tests are memory-safe with ASan/UBSan and race-free with TSan in
-  the validated scope, but enabling LeakSanitizer currently exposes cleanup
-  debt in C fixtures and the instrumented compiler path
-  ([#99](https://github.com/victorl2/iron-lang/issues/99)).
 - Native Windows remains outside Iron's supported compiler matrix; Windows
   users should use WSL. Secure networking CI covers both supported native
   platforms (Linux and macOS).
@@ -412,3 +458,5 @@ binary-safe TCP reads ([#85](https://github.com/victorl2/iron-lang/issues/85)),
 and bounded chunked server request decoding
 ([#88](https://github.com/victorl2/iron-lang/issues/88)), and payload-returning
 UDP receive ([#90](https://github.com/victorl2/iron-lang/issues/90)).
+Result-model ownership and strict LeakSanitizer coverage are completed in
+[#99](https://github.com/victorl2/iron-lang/issues/99).

--- a/docs/site/networking/index.html
+++ b/docs/site/networking/index.html
@@ -242,6 +242,7 @@
       <div class="sidebar-section">
         <h3>Start here</h3>
         <a href="#overview">Overview</a>
+        <a href="#ownership">Result ownership</a>
         <a href="#quick-client">First HTTP client</a>
         <a href="#errors">Errors and timeouts</a>
       </div>
@@ -285,6 +286,19 @@
         <p><strong>Operational model:</strong> networking calls are synchronous and bounded. Compose them with <code>spawn</code> for concurrency; the HTTP layer never creates hidden handler threads.</p>
       </div>
 
+      <h2 id="ownership">Result ownership and release</h2>
+      <p>HTTP, WebSocket, and explicit file result values own their returned string fields. Release every result after its last read, on success and error paths. Resource handles have a separate lifetime: close or transfer the server, connection, client, or socket first, then release the result model.</p>
+      <ul>
+        <li><code>HttpRequest.release</code>, <code>HttpResponse.release</code>, and the matching HTTP server, connection, HTTPS, pending-connection, and client result release calls</li>
+        <li><code>WebSocketResult.release</code> and <code>WebSocketMessage.release</code></li>
+        <li><code>FileReadResult.release</code>, <code>FileWriteResult.release</code>, and <code>FileInfo.release</code></li>
+        <li><code>value.release()</code> for standalone owned strings such as a dynamic <code>Http.header</code> result</li>
+      </ul>
+      <div class="code-block" data-label="owned result"><pre><code><span class="kw">val</span> response = <span class="ty">Http</span>.<span class="fn">get</span>(url, <span class="nu">5000</span>)
+<span class="kw">if</span> response.error == <span class="nu">0</span> { <span class="fn">println</span>(response.body) }
+<span class="ty">HttpResponse</span>.<span class="fn">release</span>(response)</code></pre></div>
+      <div class="callout warning"><p><strong>Consuming operation:</strong> Iron strings and models are value types. Never use a released value or a by-value alias afterwards. Response constructors clone caller inputs, so releasing a response does not invalidate the original body or headers. C callers use <code>iron_string_release</code> and the public <code>Iron_*_release</code> helpers.</p></div>
+
       <h2 id="quick-client">Your first HTTP client</h2>
       <p><code>Http.get</code> returns an <code>HttpResponse</code> value. A zero error means transport and HTTP framing succeeded; application status remains in <code>status</code>.</p>
       <div class="code-block" data-label="status_client.iron"><pre><code><span class="kw">import</span> http
@@ -296,11 +310,12 @@
     )
     <span class="kw">if</span> response.<span class="pr">error</span> != <span class="nu">0</span> {
         <span class="fn">println</span>(<span class="st">"request failed: {response.error} {response.error_message}"</span>)
-        <span class="kw">return</span>
     }
-
-    <span class="fn">println</span>(<span class="st">"HTTP {response.status} {response.reason}"</span>)
-    <span class="fn">println</span>(response.<span class="pr">body</span>)
+    <span class="kw">if</span> response.<span class="pr">error</span> == <span class="nu">0</span> {
+        <span class="fn">println</span>(<span class="st">"HTTP {response.status} {response.reason}"</span>)
+        <span class="fn">println</span>(response.<span class="pr">body</span>)
+    }
+    <span class="ty">HttpResponse</span>.<span class="fn">release</span>(response)
 }</code></pre></div>
       <div class="code-block" data-label="terminal"><pre><code>iron build status_client.iron -o status-client
 ./status-client</code></pre></div>
@@ -320,7 +335,9 @@
     <span class="st">"http://127.0.0.1:8080/api/items"</span>,
     <span class="st">"\{\"name\":\"anvil\"\}"</span>,
     <span class="nu">5000</span>,
-)</code></pre></div>
+)
+<span class="cm">-- use response, then consume its owned strings</span>
+<span class="ty">HttpResponse</span>.<span class="fn">release</span>(response)</code></pre></div>
 
       <h3>Custom methods and headers</h3>
       <div class="code-block" data-label="general request"><pre><code><span class="kw">val</span> response = <span class="ty">Http</span>.<span class="fn">request</span>(
@@ -330,7 +347,8 @@
     <span class="st">"\{\"name\":\"hammer\"\}"</span>,
     <span class="nu">1048576</span>,  <span class="cm">-- maximum decoded response body</span>
     <span class="nu">5000</span>,     <span class="cm">-- complete request budget</span>
-)</code></pre></div>
+)
+<span class="ty">HttpResponse</span>.<span class="fn">release</span>(response)</code></pre></div>
       <p>The client owns <code>Host</code>, <code>Connection</code>, <code>Content-Length</code>, and <code>Transfer-Encoding</code>. Supplying any of them in the custom block is rejected to prevent ambiguous framing.</p>
 
       <h2 id="https">HTTPS and certificates</h2>
@@ -348,23 +366,39 @@
     <span class="st">"POST"</span>, <span class="st">"https://localhost:8443/api/items"</span>,
     <span class="st">"Content-Type: application/json"</span>, <span class="st">"\{\"name\":\"anvil\"\}"</span>,
     <span class="nu">1048576</span>, <span class="st">"cert.pem"</span>, <span class="nu">5000</span>,
-)</code></pre></div>
+)
+<span class="ty">HttpResponse</span>.<span class="fn">release</span>(public_api)
+<span class="ty">HttpResponse</span>.<span class="fn">release</span>(private_ca)
+<span class="ty">HttpResponse</span>.<span class="fn">release</span>(created)</code></pre></div>
       <p><code>Http.get_insecure</code> and <code>Http.request_insecure</code> are explicitly unsafe development escape hatches. Never use them with production credentials.</p>
       <div class="code-block" data-label="HTTPS server"><pre><code><span class="kw">val</span> listening = <span class="ty">Http</span>.<span class="fn">listen_tls</span>(
     <span class="st">"127.0.0.1"</span>, <span class="nu">8443</span>, <span class="st">"cert.pem"</span>, <span class="st">"key.pem"</span>,
 )
 <span class="kw">val</span> pending = <span class="ty">HttpsServer</span>.<span class="fn">accept_tcp</span>(listening.server, <span class="nu">60000</span>)
 <span class="kw">if</span> pending.error == <span class="nu">0</span> {
+    <span class="kw">val</span> connection = pending.connection
+    <span class="ty">HttpsPendingConnectionResult</span>.<span class="fn">release</span>(pending)
     <span class="fn">spawn</span>(<span class="st">"tls-client"</span>) {
-        <span class="kw">val</span> secure = <span class="ty">HttpsPendingConnection</span>.<span class="fn">handshake</span>(pending.connection, <span class="nu">5000</span>)
-        <span class="kw">if</span> secure.error != <span class="nu">0</span> { <span class="kw">return</span> secure.error }
+        <span class="kw">val</span> secure = <span class="ty">HttpsPendingConnection</span>.<span class="fn">handshake</span>(connection, <span class="nu">5000</span>)
+        <span class="kw">if</span> secure.error != <span class="nu">0</span> {
+            <span class="kw">val</span> error = secure.error
+            <span class="ty">HttpsConnectionResult</span>.<span class="fn">release</span>(secure)
+            <span class="kw">return</span> error
+        }
         <span class="kw">val</span> request = <span class="ty">HttpsConnection</span>.<span class="fn">read_request</span>(
             secure.connection, <span class="nu">16384</span>, <span class="nu">1048576</span>, <span class="nu">5000</span>,
         )
+        <span class="kw">val</span> error = request.error
+        <span class="ty">HttpRequest</span>.<span class="fn">release</span>(request)
         <span class="ty">HttpsConnection</span>.<span class="fn">close</span>(secure.connection)
-        <span class="kw">return</span> request.error
+        <span class="ty">HttpsConnectionResult</span>.<span class="fn">release</span>(secure)
+        <span class="kw">return</span> error
     }
-}</code></pre></div>
+} <span class="kw">else</span> {
+    <span class="ty">HttpsPendingConnectionResult</span>.<span class="fn">release</span>(pending)
+}
+<span class="ty">HttpsServer</span>.<span class="fn">close</span>(listening.server)
+<span class="ty">HttpsServerResult</span>.<span class="fn">release</span>(listening)</code></pre></div>
       <p><code>accept_tcp</code> is bounded only by the listener deadline. Each spawned handler gets a separate TLS handshake deadline, so a raw client that sends no ClientHello cannot block later clients. Handshake consumes the pending connection on either outcome; call <code>HttpsPendingConnection.close</code> when abandoning it. The one-step <code>HttpsServer.accept</code> remains available for controlled servers.</p>
       <div class="callout"><p><strong>Certificate files:</strong> the certificate PEM may contain the leaf followed by intermediates. The private key must match. See the compiler-tested <a href="https://github.com/victorl2/iron-lang/blob/main/examples/networking/https_server.iron">HTTPS server</a> and <a href="https://github.com/victorl2/iron-lang/blob/main/examples/networking/https_client.iron">private-CA REST client</a> examples.</p></div>
       <p>Certificates are loaded when <code>listen_tls</code> creates its server context. Rotate them by starting a replacement context or restarting with the new PEM files, then drain the old listener. For graceful shutdown, stop accepting, close the server, await bound handler tasks, and close their remaining connections. Keep task handles when draining matters; intentionally detached handlers cannot be awaited.</p>
@@ -380,7 +414,10 @@
 <span class="kw">val</span> second = <span class="ty">HttpClient</span>.<span class="fn">request</span>(
     opened.client, <span class="st">"GET"</span>, <span class="st">"/api/items"</span>, <span class="st">""</span>, <span class="st">""</span>, <span class="nu">1048576</span>, <span class="nu">5000</span>,
 )
-<span class="ty">HttpClient</span>.<span class="fn">close</span>(opened.client)</code></pre></div>
+<span class="ty">HttpClient</span>.<span class="fn">close</span>(opened.client)
+<span class="ty">HttpResponse</span>.<span class="fn">release</span>(first)
+<span class="ty">HttpResponse</span>.<span class="fn">release</span>(second)
+<span class="ty">HttpClientResult</span>.<span class="fn">release</span>(opened)</code></pre></div>
       <p>The origin locks scheme, host, port, trust roots, and verification mode. It accepts only an authority with an optional trailing slash; paths, queries, fragments, and TLS-only options on plain HTTP are rejected rather than silently ignored. The connection limit bounds concurrent sockets; the idle timeout retires old entries. A stale socket is replayed once only for bodyless GET or HEAD—potentially non-idempotent requests are never retried automatically.</p>
       <div class="callout"><p><strong>Server bounds:</strong> loop over <code>read_request</code> with an idle deadline and maximum request count, then pass <code>request.keep_alive</code> to <code>send_response_keep_alive</code>. Responses always carry <code>Content-Length</code>. HTTP pipelining is intentionally unsupported; graceful shutdown closes the listener first and then drains bounded handlers.</p></div>
 
@@ -395,6 +432,8 @@
     <span class="kw">if</span> request.<span class="pr">error</span> != <span class="nu">0</span> {
         <span class="kw">val</span> bad = <span class="ty">Http</span>.<span class="fn">text_response</span>(<span class="nu">400</span>, <span class="st">"bad request"</span>)
         <span class="kw">val</span> sent = <span class="ty">HttpConnection</span>.<span class="fn">send_response</span>(connection, bad, <span class="nu">5000</span>)
+        <span class="ty">HttpResponse</span>.<span class="fn">release</span>(bad)
+        <span class="ty">HttpRequest</span>.<span class="fn">release</span>(request)
         <span class="ty">HttpConnection</span>.<span class="fn">close</span>(connection)
         <span class="kw">return</span> sent
     }
@@ -402,6 +441,8 @@
     <span class="kw">if</span> request.<span class="pr">method</span> == <span class="st">"GET"</span> <span class="kw">and</span> request.<span class="pr">path</span> == <span class="st">"/"</span> {
         <span class="kw">val</span> page = <span class="ty">Http</span>.<span class="fn">html_response</span>(<span class="nu">200</span>, <span class="st">"&lt;h1&gt;Hello from Iron&lt;/h1&gt;"</span>)
         <span class="kw">val</span> sent = <span class="ty">HttpConnection</span>.<span class="fn">send_response</span>(connection, page, <span class="nu">5000</span>)
+        <span class="ty">HttpResponse</span>.<span class="fn">release</span>(page)
+        <span class="ty">HttpRequest</span>.<span class="fn">release</span>(request)
         <span class="ty">HttpConnection</span>.<span class="fn">close</span>(connection)
         <span class="kw">return</span> sent
     }
@@ -409,6 +450,8 @@
     <span class="kw">if</span> request.<span class="pr">method</span> == <span class="st">"GET"</span> <span class="kw">and</span> request.<span class="pr">path</span> == <span class="st">"/api/status"</span> {
         <span class="kw">val</span> response = <span class="ty">Http</span>.<span class="fn">json_response</span>(<span class="nu">200</span>, <span class="st">"\{\"status\":\"ok\"\}"</span>)
         <span class="kw">val</span> sent = <span class="ty">HttpConnection</span>.<span class="fn">send_response</span>(connection, response, <span class="nu">5000</span>)
+        <span class="ty">HttpResponse</span>.<span class="fn">release</span>(response)
+        <span class="ty">HttpRequest</span>.<span class="fn">release</span>(request)
         <span class="ty">HttpConnection</span>.<span class="fn">close</span>(connection)
         <span class="kw">return</span> sent
     }
@@ -416,12 +459,16 @@
     <span class="kw">if</span> request.<span class="pr">method</span> == <span class="st">"POST"</span> <span class="kw">and</span> request.<span class="pr">path</span> == <span class="st">"/api/items"</span> {
         <span class="kw">val</span> response = <span class="ty">Http</span>.<span class="fn">json_response</span>(<span class="nu">201</span>, <span class="st">"\{\"created\":true\}"</span>)
         <span class="kw">val</span> sent = <span class="ty">HttpConnection</span>.<span class="fn">send_response</span>(connection, response, <span class="nu">5000</span>)
+        <span class="ty">HttpResponse</span>.<span class="fn">release</span>(response)
+        <span class="ty">HttpRequest</span>.<span class="fn">release</span>(request)
         <span class="ty">HttpConnection</span>.<span class="fn">close</span>(connection)
         <span class="kw">return</span> sent
     }
 
     <span class="kw">val</span> missing = <span class="ty">Http</span>.<span class="fn">json_response</span>(<span class="nu">404</span>, <span class="st">"\{\"error\":\"not found\"\}"</span>)
     <span class="kw">val</span> sent = <span class="ty">HttpConnection</span>.<span class="fn">send_response</span>(connection, missing, <span class="nu">5000</span>)
+    <span class="ty">HttpResponse</span>.<span class="fn">release</span>(missing)
+    <span class="ty">HttpRequest</span>.<span class="fn">release</span>(request)
     <span class="ty">HttpConnection</span>.<span class="fn">close</span>(connection)
     <span class="kw">return</span> sent
 }
@@ -430,15 +477,22 @@
     <span class="kw">val</span> listening = <span class="ty">Http</span>.<span class="fn">listen</span>(<span class="st">"127.0.0.1"</span>, <span class="nu">8080</span>)
     <span class="kw">if</span> listening.<span class="pr">error</span> != <span class="nu">0</span> {
         <span class="fn">println</span>(<span class="st">"listen failed: {listening.error_message}"</span>)
+        <span class="ty">HttpServerResult</span>.<span class="fn">release</span>(listening)
         <span class="kw">return</span>
     }
+    <span class="kw">val</span> server = listening.server
+    <span class="ty">HttpServerResult</span>.<span class="fn">release</span>(listening)
 
     <span class="kw">while</span> <span class="kw">true</span> {
-        <span class="kw">val</span> accepted = <span class="ty">HttpServer</span>.<span class="fn">accept</span>(listening.<span class="pr">server</span>, <span class="nu">60000</span>)
+        <span class="kw">val</span> accepted = <span class="ty">HttpServer</span>.<span class="fn">accept</span>(server, <span class="nu">60000</span>)
         <span class="kw">if</span> accepted.<span class="pr">error</span> == <span class="nu">0</span> {
+            <span class="kw">val</span> connection = accepted.connection
+            <span class="ty">HttpConnectionResult</span>.<span class="fn">release</span>(accepted)
             <span class="kw">spawn</span>(<span class="st">"http-request"</span>) {
-                <span class="kw">return</span> <span class="fn">handle</span>(accepted.<span class="pr">connection</span>)
+                <span class="kw">return</span> <span class="fn">handle</span>(connection)
             }
+        } <span class="kw">else</span> {
+            <span class="ty">HttpConnectionResult</span>.<span class="fn">release</span>(accepted)
         }
     }
 }</code></pre></div>
@@ -461,13 +515,17 @@
       <div class="code-block" data-label="HTML"><pre><code><span class="kw">val</span> page = <span class="ty">Http</span>.<span class="fn">html_response</span>(
     <span class="nu">200</span>,
     <span class="st">"&lt;!doctype html&gt;&lt;h1&gt;Iron is online&lt;/h1&gt;"</span>,
-)</code></pre></div>
+)
+<span class="cm">-- send page, then release it</span>
+<span class="ty">HttpResponse</span>.<span class="fn">release</span>(page)</code></pre></div>
       <div class="code-block" data-label="bounded file"><pre><code><span class="kw">val</span> asset = <span class="ty">Http</span>.<span class="fn">file_response</span>(
     <span class="nu">200</span>,
     <span class="st">"public/index.html"</span>,
     <span class="st">"text/html; charset=utf-8"</span>,
     <span class="nu">1048576</span>,
-)</code></pre></div>
+)
+<span class="cm">-- send asset, then release it</span>
+<span class="ty">HttpResponse</span>.<span class="fn">release</span>(asset)</code></pre></div>
       <p><code>file_response</code> reads at most the supplied limit. Choose the content type explicitly; Iron does not guess it from the filename.</p>
 
       <h2 id="files">Text and binary file operations</h2>
@@ -479,11 +537,17 @@
 <span class="kw">if</span> loaded.error == <span class="nu">0</span> {
     <span class="kw">val</span> info = <span class="ty">IO</span>.<span class="fn">file_info</span>(<span class="st">"asset.bin"</span>)
     <span class="fn">println</span>(<span class="st">"loaded {info.size} bytes"</span>)
+    <span class="ty">FileInfo</span>.<span class="fn">release</span>(info)
 }
 
 <span class="kw">val</span> appended = <span class="ty">IO</span>.<span class="fn">append_bytes</span>(<span class="st">"asset.bin"</span>, <span class="st">"\0suffix"</span>)
 <span class="kw">val</span> copied = <span class="ty">IO</span>.<span class="fn">copy_file</span>(<span class="st">"asset.bin"</span>, <span class="st">"asset-copy.bin"</span>, <span class="kw">false</span>)
-<span class="kw">val</span> moved = <span class="ty">IO</span>.<span class="fn">move_file</span>(<span class="st">"asset-copy.bin"</span>, <span class="st">"archive.bin"</span>, <span class="kw">false</span>)</code></pre></div>
+<span class="kw">val</span> moved = <span class="ty">IO</span>.<span class="fn">move_file</span>(<span class="st">"asset-copy.bin"</span>, <span class="st">"archive.bin"</span>, <span class="kw">false</span>)
+<span class="ty">FileWriteResult</span>.<span class="fn">release</span>(written)
+<span class="ty">FileReadResult</span>.<span class="fn">release</span>(loaded)
+<span class="ty">FileWriteResult</span>.<span class="fn">release</span>(appended)
+<span class="ty">FileWriteResult</span>.<span class="fn">release</span>(copied)
+<span class="ty">FileWriteResult</span>.<span class="fn">release</span>(moved)</code></pre></div>
       <p><code>read_text</code> and <code>read_bytes</code> reject an oversized file before allocating. Write and append operations report committed bytes and expose open, write, flush, and close failures. <code>copy_file</code> and <code>move_file</code> require an explicit overwrite choice. With <code>overwrite=false</code>, move uses an atomic no-replace commit: a concurrently created destination wins intact and the source remains. Unsupported filesystems return an error instead of using a racy check-then-rename.</p>
 
       <h2 id="websocket">WebSocket and secure WebSocket</h2>
@@ -493,7 +557,9 @@
     <span class="st">"Authorization: Bearer token"</span>,
     [<span class="st">"graphql-transport-ws"</span>, <span class="st">"graphql-ws"</span>],
     <span class="nu">1048576</span>, <span class="nu">5000</span>,
-)</code></pre></div>
+)
+<span class="cm">-- use/close connected.socket, then consume the result strings</span>
+<span class="ty">WebSocketResult</span>.<span class="fn">release</span>(connected)</code></pre></div>
       <p>Requested protocols preserve preference order. A server uses <code>upgrade_websocket_protocol</code> to select zero or one exact offered token; the negotiated value is returned as <code>connected.protocol</code>. Unsolicited or multiple selections fail the handshake. Raw <code>Sec-WebSocket-*</code> overrides remain forbidden, and extensions are never negotiated until Iron implements their frame semantics.</p>
       <div class="code-block" data-label="WSS client"><pre><code><span class="kw">import</span> websocket
 
@@ -506,12 +572,17 @@
     <span class="kw">val</span> sent = <span class="ty">WebSocket</span>.<span class="fn">send_text</span>(connected.socket, <span class="st">"subscribe"</span>, <span class="nu">5000</span>)
     <span class="kw">val</span> message = <span class="ty">WebSocket</span>.<span class="fn">receive</span>(connected.socket, <span class="nu">30000</span>)
     <span class="kw">val</span> closed = <span class="ty">WebSocket</span>.<span class="fn">close</span>(connected.socket, <span class="nu">1000</span>, <span class="st">"done"</span>, <span class="nu">5000</span>)
-}</code></pre></div>
+    <span class="ty">WebSocketMessage</span>.<span class="fn">release</span>(message)
+}
+<span class="ty">WebSocketResult</span>.<span class="fn">release</span>(connected)</code></pre></div>
       <p>Message kinds are <code>1</code> text, <code>2</code> binary, <code>8</code> close, <code>9</code> ping, and <code>10</code> pong. Ping is answered automatically. Fragmented messages are reassembled under the connection limit; text and close reasons are UTF-8 validated.</p>
       <div class="code-block" data-label="server upgrade"><pre><code><span class="kw">val</span> request = <span class="ty">HttpConnection</span>.<span class="fn">read_request</span>(connection, <span class="nu">16384</span>, <span class="nu">1024</span>, <span class="nu">5000</span>)
 <span class="kw">val</span> upgraded = <span class="ty">HttpConnection</span>.<span class="fn">upgrade_websocket</span>(
     connection, request, <span class="nu">1048576</span>, <span class="nu">5000</span>,
-)</code></pre></div>
+)
+<span class="ty">HttpRequest</span>.<span class="fn">release</span>(request)
+<span class="cm">-- use/close upgraded.socket, then release the model</span>
+<span class="ty">WebSocketResult</span>.<span class="fn">release</span>(upgraded)</code></pre></div>
       <div class="callout"><p><strong>Ownership:</strong> a successful upgrade transfers the HTTP connection to the WebSocket. Use one receiving task and any number of sending tasks; frame writes are serialized. Do not race close or abort with another operation.</p></div>
 
       <h2 id="concurrency">Concurrency and ownership</h2>
@@ -523,7 +594,9 @@
 <span class="kw">val</span> second = <span class="kw">spawn</span>(<span class="st">"client-2"</span>) { <span class="kw">return</span> <span class="ty">Http</span>.<span class="fn">get</span>(url2, <span class="nu">5000</span>) }
 
 <span class="kw">val</span> a = <span class="kw">await</span> first
-<span class="kw">val</span> b = <span class="kw">await</span> second</code></pre></div>
+<span class="kw">val</span> b = <span class="kw">await</span> second
+<span class="ty">HttpResponse</span>.<span class="fn">release</span>(a)
+<span class="ty">HttpResponse</span>.<span class="fn">release</span>(b)</code></pre></div>
       <ul>
         <li>Every accepted connection has explicit ownership and must be closed.</li>
         <li>A slow connection consumes its handler task until its deadline expires.</li>
@@ -631,7 +704,7 @@
       <h2 id="status">Current implementation status</h2>
       <p><span class="status">● Verified remotely</span> TCP, UDP, IP, DNS, HTTP/HTTPS clients and servers, REST JSON, webpage serving, WebSocket/WSS (including one secure reader with 24 secure writers), exact binary files, and concurrent <code>spawn</code>/<code>await</code> composition pass the Linux x86_64 Debug and Release suites.</p>
       <div class="callout warning">
-        <p><strong>Platform note:</strong> verified TLS and installed-compiler HTTPS builds run in Linux and macOS CI. The reproducible <code>silvaserver.local</code> validation image includes the matching Clang 14 ASan/UBSan/TSan runtimes and OpenSSL development files; its focused networking, concurrency, and file battery passes 8/8 under ASan/UBSan and 8/8 under TSan. CMake fails incomplete sanitizer toolchains during configuration. LeakSanitizer cleanup debt is tracked in <a href="https://github.com/victorl2/iron-lang/issues/99">issue #99</a>. Native Windows is not yet a supported Iron compiler target; use WSL there. Without OpenSSL development headers, plain networking remains available and secure calls return a typed TLS-unavailable error.</p>
+        <p><strong>Platform note:</strong> verified TLS and installed-compiler HTTPS builds run in Linux and macOS CI. The reproducible <code>silvaserver.local</code> validation image includes the matching Clang 14 ASan/UBSan/TSan runtimes and OpenSSL development files; its focused networking, concurrency, and file battery passes 8/8 under ASan/UBSan with LeakSanitizer enabled and 8/8 under TSan. CMake fails incomplete sanitizer toolchains during configuration. Native Windows is not yet a supported Iron compiler target; use WSL there. Without OpenSSL development headers, plain networking remains available and secure calls return a typed TLS-unavailable error.</p>
       </div>
       <p>See the <a href="https://github.com/victorl2/iron-lang/blob/main/docs/networking.md">maintained validation matrix</a> and <a href="https://github.com/victorl2/iron-lang/tree/main/examples/networking">networking examples</a> for source-level evidence.</p>
 

--- a/examples/networking/README.md
+++ b/examples/networking/README.md
@@ -21,6 +21,9 @@ must be awaited; leave it standalone for an intentionally detached handler.
 
 The complete practical guide is published at
 [ironlang.dev/networking](https://ironlang.dev/networking/).
+Every example also demonstrates the consuming `release` calls required for
+HTTP, WebSocket, and file result strings. Close or transfer a resource handle
+first, then release its result model; never reuse a by-value alias afterwards.
 
 Additional compiler-tested examples:
 

--- a/examples/networking/file_operations.iron
+++ b/examples/networking/file_operations.iron
@@ -10,11 +10,14 @@ func main() {
     val written = IO.write_bytes(path, payload)
     if written.error != 0 {
         println("write failed: {written.error} {written.error_message}")
+        FileWriteResult.release(written)
         return
     }
     val read = IO.read_bytes(path, 1024)
     if read.error != 0 {
         println("read failed: {read.error} {read.error_message}")
+        FileWriteResult.release(written)
+        FileReadResult.release(read)
         return
     }
     val info = IO.file_info(path)
@@ -27,4 +30,9 @@ func main() {
 
     IO.delete_file(path)
     IO.delete_file(moved)
+    FileWriteResult.release(written)
+    FileReadResult.release(read)
+    FileInfo.release(info)
+    FileWriteResult.release(copied)
+    FileWriteResult.release(renamed)
 }

--- a/examples/networking/http_keep_alive.iron
+++ b/examples/networking/http_keep_alive.iron
@@ -9,14 +9,18 @@ func handle_session(connection: HttpConnection) -> Int {
         val request = HttpConnection.read_request(
             connection, 16384, 1048576, 15000)
         if request.error != 0 {
+            val error = request.error
+            HttpRequest.release(request)
             HttpConnection.close(connection)
-            return request.error
+            return error
         }
         served += 1
         val keep = request.keep_alive and served < 100
         val response = Http.json_response(200, "\{\"status\":\"ok\"\}")
         val sent = HttpConnection.send_response_keep_alive(
             connection, response, keep, 5000)
+        HttpResponse.release(response)
+        HttpRequest.release(request)
         if sent != 0 {
             HttpConnection.close(connection)
             return sent
@@ -32,6 +36,7 @@ func main() {
         "http://127.0.0.1:8080", "", false, 4, 30000)
     if opened.error != 0 {
         println("client failed: {opened.error} {opened.error_message}")
+        HttpClientResult.release(opened)
         return
     }
     val first = HttpClient.request(
@@ -40,4 +45,7 @@ func main() {
         opened.client, "GET", "/api/status", "", "", 1048576, 5000)
     println("first={first.status} second={second.status}")
     HttpClient.close(opened.client)
+    HttpResponse.release(first)
+    HttpResponse.release(second)
+    HttpClientResult.release(opened)
 }

--- a/examples/networking/https_client.iron
+++ b/examples/networking/https_client.iron
@@ -14,7 +14,9 @@ func main() {
     )
     if response.error != 0 {
         println("HTTPS request failed: {response.error} {response.error_message}")
+        HttpResponse.release(response)
         return
     }
     println("HTTPS {response.status}: {response.body}")
+    HttpResponse.release(response)
 }

--- a/examples/networking/https_server.iron
+++ b/examples/networking/https_server.iron
@@ -8,29 +8,44 @@ func main() {
     val listening = Http.listen_tls("127.0.0.1", 8443, "cert.pem", "key.pem")
     if listening.error != 0 {
         println("TLS listen failed: {listening.error} {listening.error_message}")
+        HttpsServerResult.release(listening)
         return
     }
+    val server = listening.server
+    HttpsServerResult.release(listening)
     println("HTTPS page: https://localhost:8443/")
     while true {
         -- TCP admission remains prompt even if another client never sends a
         -- TLS ClientHello. Each handler owns its bounded handshake.
-        val accepted = HttpsServer.accept_tcp(listening.server, 60000)
+        val accepted = HttpsServer.accept_tcp(server, 60000)
         if accepted.error == 0 {
+            val pending = accepted.connection
+            HttpsPendingConnectionResult.release(accepted)
             spawn("https-request") {
-                val secure = HttpsPendingConnection.handshake(accepted.connection, 5000)
+                val secure = HttpsPendingConnection.handshake(pending, 5000)
                 if secure.error != 0 {
-                    return secure.error
+                    val error = secure.error
+                    HttpsConnectionResult.release(secure)
+                    return error
                 }
                 val request = HttpsConnection.read_request(secure.connection, 16384, 1048576, 5000)
                 if request.error == 0 {
                     val page = Http.html_response(200, "<!doctype html><title>Iron HTTPS</title><h1>Secure Iron works</h1>")
                     val sent = HttpsConnection.send_response(secure.connection, page, 5000)
+                    HttpResponse.release(page)
+                    HttpRequest.release(request)
                     HttpsConnection.close(secure.connection)
+                    HttpsConnectionResult.release(secure)
                     return sent
                 }
+                val error = request.error
+                HttpRequest.release(request)
                 HttpsConnection.close(secure.connection)
-                return request.error
+                HttpsConnectionResult.release(secure)
+                return error
             }
+        } else {
+            HttpsPendingConnectionResult.release(accepted)
         }
     }
 }

--- a/examples/networking/rest_server.iron
+++ b/examples/networking/rest_server.iron
@@ -9,6 +9,8 @@ func handle(connection: HttpConnection) -> Int {
     if request.error != 0 {
         val bad = Http.text_response(400, "bad request")
         val ignored = HttpConnection.send_response(connection, bad, 5000)
+        HttpResponse.release(bad)
+        HttpRequest.release(request)
         HttpConnection.close(connection)
         return ignored
     }
@@ -16,6 +18,8 @@ func handle(connection: HttpConnection) -> Int {
     if request.method == "GET" and request.path == "/" {
         val page = Http.html_response(200, "<!doctype html><html><head><title>Iron</title></head><body><h1>Iron networking works</h1><p>Try <code>/api/status</code>.</p></body></html>")
         val sent = HttpConnection.send_response(connection, page, 5000)
+        HttpResponse.release(page)
+        HttpRequest.release(request)
         HttpConnection.close(connection)
         return sent
     }
@@ -23,6 +27,8 @@ func handle(connection: HttpConnection) -> Int {
     if request.method == "GET" and request.path == "/api/status" {
         val response = Http.json_response(200, "\{\"status\":\"ok\",\"language\":\"iron\"\}")
         val sent = HttpConnection.send_response(connection, response, 5000)
+        HttpResponse.release(response)
+        HttpRequest.release(request)
         HttpConnection.close(connection)
         return sent
     }
@@ -30,12 +36,16 @@ func handle(connection: HttpConnection) -> Int {
     if request.method == "POST" and request.path == "/api/items" {
         val response = Http.json_response(201, "\{\"created\":true\}")
         val sent = HttpConnection.send_response(connection, response, 5000)
+        HttpResponse.release(response)
+        HttpRequest.release(request)
         HttpConnection.close(connection)
         return sent
     }
 
     val missing = Http.json_response(404, "\{\"error\":\"not found\"\}")
     val sent = HttpConnection.send_response(connection, missing, 5000)
+    HttpResponse.release(missing)
+    HttpRequest.release(request)
     HttpConnection.close(connection)
     return sent
 }
@@ -44,18 +54,25 @@ func main() {
     val result = Http.listen("127.0.0.1", 8080)
     if result.error != 0 {
         println("listen failed: {result.error} {result.error_message}")
+        HttpServerResult.release(result)
         return
     }
+    val server = result.server
+    HttpServerResult.release(result)
     println("Iron HTTP listening on http://127.0.0.1:8080")
     while true {
-        val accepted = HttpServer.accept(result.server, 60000)
+        val accepted = HttpServer.accept(server, 60000)
         if accepted.error == 0 {
+            val connection = accepted.connection
+            HttpConnectionResult.release(accepted)
             -- A standalone spawn is intentionally detached and uses the
             -- runtime pool. Bind it to `val task = spawn(...)` when a caller
             -- needs to await a result instead.
             spawn("http-request") {
-                return handle(accepted.connection)
+                return handle(connection)
             }
+        } else {
+            HttpConnectionResult.release(accepted)
         }
     }
 }

--- a/examples/networking/websocket_client.iron
+++ b/examples/networking/websocket_client.iron
@@ -6,6 +6,7 @@ func main() {
         "ws://127.0.0.1:8081/echo", "", ["iron.echo.v1"], 1048576, 5000)
     if connected.error != 0 {
         println("connect failed: {connected.error} {connected.error_message}")
+        WebSocketResult.release(connected)
         return
     }
     println("protocol: {connected.protocol}")
@@ -13,6 +14,7 @@ func main() {
     if sent != 0 {
         println("send failed: {sent}")
         WebSocket.abort(connected.socket)
+        WebSocketResult.release(connected)
         return
     }
     val reply = WebSocket.receive(connected.socket, 5000)
@@ -23,4 +25,6 @@ func main() {
     }
     val closed = WebSocket.close(connected.socket, 1000, "done", 5000)
     if closed != 0 { println("close warning: {closed}") }
+    WebSocketMessage.release(reply)
+    WebSocketResult.release(connected)
 }

--- a/examples/networking/websocket_echo_secure_server.iron
+++ b/examples/networking/websocket_echo_secure_server.iron
@@ -5,39 +5,57 @@ import websocket
 func handle_secure_websocket(connection: HttpsConnection) -> Int {
     val request = HttpsConnection.read_request(connection, 16384, 1024, 5000)
     if request.error != 0 {
+        val error = request.error
+        HttpRequest.release(request)
         HttpsConnection.close(connection)
-        return request.error
+        return error
     }
     val upgraded = HttpsConnection.upgrade_websocket(connection, request, 1048576, 5000)
     if upgraded.error != 0 {
+        val error = upgraded.error
+        WebSocketResult.release(upgraded)
+        HttpRequest.release(request)
         HttpsConnection.close(connection)
-        return upgraded.error
+        return error
     }
+    HttpRequest.release(request)
     while WebSocket.is_open(upgraded.socket) {
         val message = WebSocket.receive(upgraded.socket, 60000)
         if message.error != 0 {
+            val error = message.error
+            WebSocketMessage.release(message)
             WebSocket.abort(upgraded.socket)
-            return message.error
+            WebSocketResult.release(upgraded)
+            return error
         }
         if message.kind == 8 {
+            WebSocketMessage.release(message)
             WebSocket.abort(upgraded.socket)
+            WebSocketResult.release(upgraded)
             return 0
         }
         if message.kind == 1 {
             val sent = WebSocket.send_text(upgraded.socket, message.data, 5000)
             if sent != 0 {
+                WebSocketMessage.release(message)
                 WebSocket.abort(upgraded.socket)
+                WebSocketResult.release(upgraded)
                 return sent
             }
         }
         if message.kind == 2 {
             val sent = WebSocket.send_bytes(upgraded.socket, message.data, 5000)
             if sent != 0 {
+                WebSocketMessage.release(message)
                 WebSocket.abort(upgraded.socket)
+                WebSocketResult.release(upgraded)
                 return sent
             }
         }
+        WebSocketMessage.release(message)
     }
+    WebSocket.abort(upgraded.socket)
+    WebSocketResult.release(upgraded)
     return 0
 }
 
@@ -45,19 +63,30 @@ func main() {
     val listening = Http.listen_tls("127.0.0.1", 8444, "cert.pem", "key.pem")
     if listening.error != 0 {
         println("WSS listen failed: {listening.error} {listening.error_message}")
+        HttpsServerResult.release(listening)
         return
     }
+    val server = listening.server
+    HttpsServerResult.release(listening)
     println("Secure WebSocket echo server: wss://localhost:8444/echo")
     while true {
-        val accepted = HttpsServer.accept_tcp(listening.server, 60000)
+        val accepted = HttpsServer.accept_tcp(server, 60000)
         if accepted.error == 0 {
+            val pending = accepted.connection
+            HttpsPendingConnectionResult.release(accepted)
             spawn("secure-websocket-client") {
-                val secure = HttpsPendingConnection.handshake(accepted.connection, 5000)
+                val secure = HttpsPendingConnection.handshake(pending, 5000)
                 if secure.error != 0 {
-                    return secure.error
+                    val error = secure.error
+                    HttpsConnectionResult.release(secure)
+                    return error
                 }
-                return handle_secure_websocket(secure.connection)
+                val result = handle_secure_websocket(secure.connection)
+                HttpsConnectionResult.release(secure)
+                return result
             }
+        } else {
+            HttpsPendingConnectionResult.release(accepted)
         }
     }
 }

--- a/examples/networking/websocket_echo_server.iron
+++ b/examples/networking/websocket_echo_server.iron
@@ -7,40 +7,58 @@ import websocket
 func handle_websocket(connection: HttpConnection) -> Int {
     val request = HttpConnection.read_request(connection, 16384, 1024, 5000)
     if request.error != 0 {
+        val error = request.error
+        HttpRequest.release(request)
         HttpConnection.close(connection)
-        return request.error
+        return error
     }
     val upgraded = HttpConnection.upgrade_websocket_protocol(
         connection, request, "iron.echo.v1", 1048576, 5000)
     if upgraded.error != 0 {
+        val error = upgraded.error
+        WebSocketResult.release(upgraded)
+        HttpRequest.release(request)
         HttpConnection.close(connection)
-        return upgraded.error
+        return error
     }
+    HttpRequest.release(request)
     while WebSocket.is_open(upgraded.socket) {
         val message = WebSocket.receive(upgraded.socket, 60000)
         if message.error != 0 {
+            val error = message.error
+            WebSocketMessage.release(message)
             WebSocket.abort(upgraded.socket)
-            return message.error
+            WebSocketResult.release(upgraded)
+            return error
         }
         if message.kind == 8 {
+            WebSocketMessage.release(message)
             WebSocket.abort(upgraded.socket)
+            WebSocketResult.release(upgraded)
             return 0
         }
         if message.kind == 1 {
             val sent = WebSocket.send_text(upgraded.socket, message.data, 5000)
             if sent != 0 {
+                WebSocketMessage.release(message)
                 WebSocket.abort(upgraded.socket)
+                WebSocketResult.release(upgraded)
                 return sent
             }
         }
         if message.kind == 2 {
             val sent = WebSocket.send_bytes(upgraded.socket, message.data, 5000)
             if sent != 0 {
+                WebSocketMessage.release(message)
                 WebSocket.abort(upgraded.socket)
+                WebSocketResult.release(upgraded)
                 return sent
             }
         }
+        WebSocketMessage.release(message)
     }
+    WebSocket.abort(upgraded.socket)
+    WebSocketResult.release(upgraded)
     return 0
 }
 
@@ -48,15 +66,22 @@ func main() {
     val listening = Http.listen("127.0.0.1", 8081)
     if listening.error != 0 {
         println("listen failed: {listening.error} {listening.error_message}")
+        HttpServerResult.release(listening)
         return
     }
+    val server = listening.server
+    HttpServerResult.release(listening)
     println("WebSocket echo server: ws://127.0.0.1:8081/echo")
     while true {
-        val accepted = HttpServer.accept(listening.server, 60000)
+        val accepted = HttpServer.accept(server, 60000)
         if accepted.error == 0 {
+            val connection = accepted.connection
+            HttpConnectionResult.release(accepted)
             spawn("websocket-client") {
-                return handle_websocket(accepted.connection)
+                return handle_websocket(connection)
             }
+        } else {
+            HttpConnectionResult.release(accepted)
         }
     }
 }

--- a/src/lsp/obs/parent_watch.c
+++ b/src/lsp/obs/parent_watch.c
@@ -113,6 +113,7 @@ int ilsp_parent_watch_init(void) {
 
 #if defined(__linux__)
     /* Linux: kernel-managed, zero threads. */
+    pid_t parent_before_install = getppid();
     if (prctl(PR_SET_PDEATHSIG, SIGTERM, 0, 0, 0) != 0) {
         int saved = errno;
         ilsp_log(ILSP_LOG_WARN, "parent-watch",
@@ -120,12 +121,13 @@ int ilsp_parent_watch_init(void) {
         atomic_store(&s_installed, 0);
         return -1;
     }
-    /* Race-guard: if parent already died between fork and this call,
-     * PPID has already become 1 and no SIGTERM will be delivered. Check
-     * once here. */
-    if (getppid() == 1) {
+    /* Race guard: if the parent died between our snapshot and prctl, the
+     * kernel could not deliver the newly configured signal. Compare PIDs
+     * rather than treating PPID 1 as inherently orphaned: inside a container,
+     * a healthy launcher or editor can legitimately be PID 1. */
+    if (getppid() != parent_before_install) {
         ilsp_log(ILSP_LOG_INFO, "parent-watch",
-                 "parent already gone at install time; self-SIGTERM");
+                 "parent changed during watcher install; self-SIGTERM");
         kill(getpid(), SIGTERM);
     }
     return 0;

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -62,20 +62,23 @@ static inline bool iron_cancel_requested(const _Atomic bool *flag) {
  *
  * Ceiling calibration note: the guard bounds PARSER stack only. The
  * historical failure attributed to this ceiling (test_parser_recursion_guard
- * SIGSEGV under Debug+ASan) was actually a post-trip amplifier: the Pratt
+ * SIGSEGV under Debug+ASan) also exposed a post-trip amplifier: the Pratt
  * climb loop is iterative, and during error recovery it wrapped the error
  * node in one call layer per leftover token — an AST whose depth was
  * bounded by INPUT LENGTH, not by this ceiling — and the analyzer (which
  * has no depth guard) overflowed on it. That amplifier is now closed at
  * the top of iron_parse_expr_prec_impl's climb loop (error nodes accrete
- * no postfix layers during recovery). Measured under Debug+ASan (arm64,
- * 8 MB stack): 900 nested parens parse clean, the trip at 1000 emits
- * E0107 with room to spare — 1000 is a safe parser-frame bound.
+ * no postfix layers during recovery). Linux x86_64 Clang 14 ASan uses larger
+ * frames than the earlier arm64 calibration and exhausted an 8 MB stack before
+ * the former 1000 ceiling; a 512-deep recovered block AST could likewise
+ * exhaust the uninstrumented analyzer recursion. The portable bound is
+ * therefore 256, still more than 25 times the maximum integration-corpus
+ * depth and above the 100-level moderate-nesting acceptance case.
  *
  * Defense-in-depth note (IN-07 flag): adding depth bumps to
  * func_or_method / object_decl would be harmless but redundant — these
  * are reached only through iron_parse_decl, already wrapped. */
-#define IRON_PARSER_MAX_DEPTH 1000
+#define IRON_PARSER_MAX_DEPTH 256
 
 /* Forward decls for helpers used before their definitions. */
 static Iron_Span   iron_token_span(Iron_Parser *p, Iron_Token *t);

--- a/src/runtime/iron_runtime.h
+++ b/src/runtime/iron_runtime.h
@@ -747,6 +747,10 @@ size_t       iron_string_codepoint_count(const Iron_String *s);
 bool         iron_string_equals(const Iron_String *a, const Iron_String *b);
 Iron_String  iron_string_concat(const Iron_String *a, const Iron_String *b);
 Iron_String  iron_string_intern(Iron_String s);
+/* Consumes one owned string value. Heap-backed interned literals remain owned
+ * by the runtime and are ignored; non-interned heap storage is freed. Any
+ * by-value aliases of a released string become invalid and must not be used. */
+void         iron_string_release(Iron_String *s);
 
 /* ── Phase 26 POL-06: rc policy runtime API ──────────────────────────────────
  *
@@ -1670,5 +1674,6 @@ int64_t               Iron_string_count(Iron_String self, Iron_String sub);
 int64_t               Iron_string_rindex_of(Iron_String self, Iron_String sub);
 int64_t               Iron_string_byte_at(Iron_String self, int64_t i);
 Iron_String           Iron_string_from_byte(int64_t b);
+void                  Iron_string_release(Iron_String self);
 
 #endif /* IRON_RUNTIME_H */

--- a/src/runtime/iron_string.c
+++ b/src/runtime/iron_string.c
@@ -263,6 +263,14 @@ Iron_String iron_string_intern(Iron_String s) {
     return interned;
 }
 
+void iron_string_release(Iron_String *s) {
+    if (!s) return;
+    if ((s->heap.flags & 0x01) && !(s->heap.flags & 0x02)) {
+        free(s->heap.data);
+    }
+    memset(s, 0, sizeof(*s));
+}
+
 /* Forward declarations for the thread subsystem (implemented in iron_threads.c) */
 void iron_threads_init(void);
 void iron_threads_shutdown(void);
@@ -712,4 +720,8 @@ Iron_String Iron_string_from_byte(int64_t b) {
     char buf[1];
     buf[0] = (char)(b & 0xff);
     return iron_string_from_cstr(buf, 1);
+}
+
+void Iron_string_release(Iron_String self) {
+    iron_string_release(&self);
 }

--- a/src/stdlib/http.iron
+++ b/src/stdlib/http.iron
@@ -103,6 +103,17 @@ object HttpResponse {
     val error_message: String
 }
 
+-- Result/model strings are owned by the returned value. `release` consumes
+-- that ownership; the value and any by-value aliases must not be used again.
+func HttpServerResult.release(result: HttpServerResult) {}
+func HttpConnectionResult.release(result: HttpConnectionResult) {}
+func HttpsServerResult.release(result: HttpsServerResult) {}
+func HttpsConnectionResult.release(result: HttpsConnectionResult) {}
+func HttpsPendingConnectionResult.release(result: HttpsPendingConnectionResult) {}
+func HttpClientResult.release(result: HttpClientResult) {}
+func HttpRequest.release(request: HttpRequest) {}
+func HttpResponse.release(response: HttpResponse) {}
+
 object Http {}
 
 -- Server lifecycle and connection I/O.

--- a/src/stdlib/io.iron
+++ b/src/stdlib/io.iron
@@ -25,6 +25,12 @@ object FileInfo {
     val error_message: String
 }
 
+-- Consuming ownership helpers. Do not use a result or a by-value alias after
+-- release; inline strings and interned literals are safe no-ops.
+func FileReadResult.release(result: FileReadResult) {}
+func FileWriteResult.release(result: FileWriteResult) {}
+func FileInfo.release(info: FileInfo) {}
+
 func IO.read_file(path: String) -> String {}
 func IO.write_file(path: String, content: String) {}
 func IO.file_exists(path: String) -> Bool {}

--- a/src/stdlib/iron_http.c
+++ b/src/stdlib/iron_http.c
@@ -121,6 +121,49 @@ static void http_response_error(Iron_HttpResponse *r, int64_t code) {
     r->error_message = http_str(http_error_message(code));
 }
 
+void Iron_httpserverresult_release(Iron_HttpServerResult result) {
+    iron_string_release(&result.error_message);
+}
+
+void Iron_httpconnectionresult_release(Iron_HttpConnectionResult result) {
+    iron_string_release(&result.error_message);
+}
+
+void Iron_httpsserverresult_release(Iron_HttpsServerResult result) {
+    iron_string_release(&result.error_message);
+}
+
+void Iron_httpsconnectionresult_release(Iron_HttpsConnectionResult result) {
+    iron_string_release(&result.error_message);
+}
+
+void Iron_httpspendingconnectionresult_release(
+    Iron_HttpsPendingConnectionResult result) {
+    iron_string_release(&result.error_message);
+}
+
+void Iron_httpclientresult_release(Iron_HttpClientResult result) {
+    iron_string_release(&result.error_message);
+}
+
+void Iron_httprequest_release(Iron_HttpRequest request) {
+    iron_string_release(&request.method);
+    iron_string_release(&request.target);
+    iron_string_release(&request.path);
+    iron_string_release(&request.query);
+    iron_string_release(&request.version);
+    iron_string_release(&request.headers);
+    iron_string_release(&request.body);
+    iron_string_release(&request.error_message);
+}
+
+void Iron_httpresponse_release(Iron_HttpResponse response) {
+    iron_string_release(&response.reason);
+    iron_string_release(&response.headers);
+    iron_string_release(&response.body);
+    iron_string_release(&response.error_message);
+}
+
 static int ascii_ieq_n(const char *a, size_t an, const char *b, size_t bn) {
     if (an != bn) return 0;
     for (size_t i = 0; i < an; i++) {
@@ -1093,8 +1136,9 @@ static const char *status_reason(int64_t status) {
     }
 }
 
-Iron_HttpResponse Iron_http_response(int64_t status, Iron_String headers,
-                                      Iron_String body) {
+static Iron_HttpResponse http_response_owned(int64_t status,
+                                              Iron_String headers,
+                                              Iron_String body) {
     Iron_HttpResponse out = http_response_empty();
     out.status = status;
     out.reason = http_str(status_reason(status));
@@ -1107,16 +1151,30 @@ Iron_HttpResponse Iron_http_response(int64_t status, Iron_String headers,
     return out;
 }
 
+Iron_HttpResponse Iron_http_response(int64_t status, Iron_String headers,
+                                      Iron_String body) {
+    return http_response_owned(
+        status,
+        http_slice(iron_string_cstr(&headers), iron_string_byte_len(&headers)),
+        http_slice(iron_string_cstr(&body), iron_string_byte_len(&body)));
+}
+
 Iron_HttpResponse Iron_http_json_response(int64_t status, Iron_String body) {
-    return Iron_http_response(status, http_str("Content-Type: application/json; charset=utf-8"), body);
+    return http_response_owned(
+        status, http_str("Content-Type: application/json; charset=utf-8"),
+        http_slice(iron_string_cstr(&body), iron_string_byte_len(&body)));
 }
 
 Iron_HttpResponse Iron_http_html_response(int64_t status, Iron_String body) {
-    return Iron_http_response(status, http_str("Content-Type: text/html; charset=utf-8"), body);
+    return http_response_owned(
+        status, http_str("Content-Type: text/html; charset=utf-8"),
+        http_slice(iron_string_cstr(&body), iron_string_byte_len(&body)));
 }
 
 Iron_HttpResponse Iron_http_text_response(int64_t status, Iron_String body) {
-    return Iron_http_response(status, http_str("Content-Type: text/plain; charset=utf-8"), body);
+    return http_response_owned(
+        status, http_str("Content-Type: text/plain; charset=utf-8"),
+        http_slice(iron_string_cstr(&body), iron_string_byte_len(&body)));
 }
 
 Iron_HttpResponse Iron_http_file_response(int64_t status, Iron_String path,
@@ -1170,7 +1228,7 @@ Iron_HttpResponse Iron_http_file_response(int64_t status, Iron_String path,
     Iron_String body_s = http_slice(buf, len);
     free(header);
     free(buf);
-    return Iron_http_response(status, header_s, body_s);
+    return http_response_owned(status, header_s, body_s);
 }
 
 static int64_t send_response_transport(HttpTransport transport,
@@ -1467,7 +1525,9 @@ Iron_HttpResponse Iron_http_get(Iron_String url, int64_t timeout) {
 Iron_HttpResponse Iron_http_post_json(Iron_String url, Iron_String body,
                                        int64_t timeout) {
     return Iron_http_request(http_str("POST"), url,
-        http_str("Content-Type: application/json; charset=utf-8"), body,
+        iron_string_from_literal(
+            "Content-Type: application/json; charset=utf-8",
+            strlen("Content-Type: application/json; charset=utf-8")), body,
         HTTP_DEFAULT_MAX_BODY, timeout);
 }
 

--- a/src/stdlib/iron_http.h
+++ b/src/stdlib/iron_http.h
@@ -75,6 +75,19 @@ typedef struct Iron_HttpResponse {
     Iron_String error_message;
 } Iron_HttpResponse;
 
+/* The string fields returned in HTTP results and models are owned by the
+ * returned value. These functions consume that ownership. Copies made before
+ * release must not be used afterwards. Resource handles are not closed. */
+void Iron_httpserverresult_release(Iron_HttpServerResult result);
+void Iron_httpconnectionresult_release(Iron_HttpConnectionResult result);
+void Iron_httpsserverresult_release(Iron_HttpsServerResult result);
+void Iron_httpsconnectionresult_release(Iron_HttpsConnectionResult result);
+void Iron_httpspendingconnectionresult_release(
+    Iron_HttpsPendingConnectionResult result);
+void Iron_httpclientresult_release(Iron_HttpClientResult result);
+void Iron_httprequest_release(Iron_HttpRequest request);
+void Iron_httpresponse_release(Iron_HttpResponse response);
+
 Iron_HttpServerResult Iron_http_listen(Iron_String host, int64_t port);
 Iron_HttpConnectionResult Iron_httpserver_accept(Iron_HttpServer server,
                                                   int64_t timeout);

--- a/src/stdlib/iron_io.c
+++ b/src/stdlib/iron_io.c
@@ -274,10 +274,12 @@ Iron_List_Iron_String Iron_io_read_lines(Iron_String path) {
     }
     Iron_String sep = iron_string_from_cstr("\n", 1);
     Iron_List_Iron_String lines = Iron_string_split(res.v0, sep);
+    iron_string_release(&res.v0);
     /* Remove trailing empty string if file ended with \n (common case) */
     if (lines.count > 0) {
         Iron_String last = lines.items[lines.count - 1];
         if (iron_string_byte_len(&last) == 0) {
+            iron_string_release(&lines.items[lines.count - 1]);
             lines.count--;
         }
     }
@@ -337,6 +339,19 @@ static Iron_FileWriteResult io_write_result(int64_t bytes, int64_t code) {
     out.error = code;
     out.error_message = io_message(code);
     return out;
+}
+
+void Iron_filereadresult_release(Iron_FileReadResult result) {
+    iron_string_release(&result.data);
+    iron_string_release(&result.error_message);
+}
+
+void Iron_filewriteresult_release(Iron_FileWriteResult result) {
+    iron_string_release(&result.error_message);
+}
+
+void Iron_fileinfo_release(Iron_FileInfo info) {
+    iron_string_release(&info.error_message);
 }
 
 static int io_path_copy(Iron_String path, char **output) {

--- a/src/stdlib/iron_io.h
+++ b/src/stdlib/iron_io.h
@@ -37,6 +37,11 @@ typedef struct Iron_FileInfo {
 } Iron_FileInfo;
 #endif
 
+/* Consume strings owned by the explicit file result models. */
+void Iron_filereadresult_release(Iron_FileReadResult result);
+void Iron_filewriteresult_release(Iron_FileWriteResult result);
+void Iron_fileinfo_release(Iron_FileInfo info);
+
 /* ── File I/O ────────────────────────────────────────────────────────────── */
 Iron_Result_String_Error Iron_io_read_file_result(Iron_String path);
 Iron_Error               Iron_io_write_file(Iron_String path, Iron_String content);

--- a/src/stdlib/iron_tls.h
+++ b/src/stdlib/iron_tls.h
@@ -19,6 +19,11 @@ typedef struct {
     Iron_NetError error;
 } Iron_TlsContextResult;
 
+/* Low-level TLS results contain handles plus numeric NetError values and own
+ * no strings. Close/free a successful handle; no result release is needed.
+ * The higher-level HTTPS models in iron_http.h do own diagnostic strings and
+ * provide matching Iron_*_release helpers. */
+
 /* Wrap an already-connected nonblocking TCP socket. `ca_file == ""` uses the
  * platform/OpenSSL default trust roots. Hostname/IP verification is mandatory
  * unless `insecure` is explicitly true. */

--- a/src/stdlib/iron_websocket.c
+++ b/src/stdlib/iron_websocket.c
@@ -115,6 +115,16 @@ static Iron_WebSocketMessage ws_message_error(int64_t error) {
     return message;
 }
 
+void Iron_websocketresult_release(Iron_WebSocketResult result) {
+    iron_string_release(&result.error_message);
+    iron_string_release(&result.protocol);
+}
+
+void Iron_websocketmessage_release(Iron_WebSocketMessage message) {
+    iron_string_release(&message.data);
+    iron_string_release(&message.error_message);
+}
+
 static int ascii_equal(const char *left, size_t left_len,
                        const char *right, size_t right_len) {
     if (left_len != right_len) return 0;

--- a/src/stdlib/iron_websocket.h
+++ b/src/stdlib/iron_websocket.h
@@ -26,6 +26,11 @@ typedef struct Iron_WebSocketMessage {
     Iron_String error_message;
 } Iron_WebSocketMessage;
 
+/* Consume strings owned by returned WebSocket models. Socket handles and
+ * transports are not closed by these helpers. */
+void Iron_websocketresult_release(Iron_WebSocketResult result);
+void Iron_websocketmessage_release(Iron_WebSocketMessage message);
+
 enum {
     IRON_WEBSOCKET_TEXT = 1,
     IRON_WEBSOCKET_BINARY = 2,

--- a/src/stdlib/string.iron
+++ b/src/stdlib/string.iron
@@ -22,6 +22,9 @@ patch object String {
     readonly func rindex_of(sub: String) -> Int {}
     readonly func byte_at(i: Int) -> Int {}
     readonly func from_byte(b: Int) -> String {}
+    -- Consumes an owned dynamic string. Do not use this value or a by-value
+    -- alias after release. Interned literals and inline strings are no-ops.
+    readonly func release() {}
 }
 
 -- Phase 59 P01c: byte-level and reverse-search primitives needed by URL

--- a/src/stdlib/websocket.iron
+++ b/src/stdlib/websocket.iron
@@ -28,6 +28,10 @@ object WebSocketMessage {
     val error_message: String
 }
 
+-- Consuming ownership helpers for strings returned in these models.
+func WebSocketResult.release(result: WebSocketResult) {}
+func WebSocketMessage.release(message: WebSocketMessage) {}
+
 -- `connect` accepts ws:// and wss://. WSS verifies the certificate chain and
 -- hostname using system roots. Custom headers are useful for Authorization or
 -- Cookie; handshake-owned headers cannot be overridden.

--- a/tests/integration/v4/7.5-stdlib/file_operations_roundtrip.iron
+++ b/tests/integration/v4/7.5-stdlib/file_operations_roundtrip.iron
@@ -14,7 +14,14 @@ func main() {
     val moved_read = IO.read_bytes(moved_path, 1024)
     IO.delete_file(source)
     IO.delete_file(moved_path)
-    if written.error == 0 and read.error == 0 and read.data == payload and info.exists and info.is_file and copied.error == 0 and moved.error == 0 and moved_read.data == payload {
+    val success = written.error == 0 and read.error == 0 and read.data == payload and info.exists and info.is_file and copied.error == 0 and moved.error == 0 and moved_read.data == payload
+    FileWriteResult.release(written)
+    FileReadResult.release(read)
+    FileInfo.release(info)
+    FileWriteResult.release(copied)
+    FileWriteResult.release(moved)
+    FileReadResult.release(moved_read)
+    if success {
         println("file operations roundtrip ok")
     } else {
         println("file operations roundtrip failed")

--- a/tests/integration/v4/7.5-stdlib/http_concurrency.iron
+++ b/tests/integration/v4/7.5-stdlib/http_concurrency.iron
@@ -4,31 +4,44 @@ import http
 
 func serve_one(server: HttpServer) -> Int {
     val accepted = HttpServer.accept(server, 10000)
-    if accepted.error != 0 { return accepted.error }
+    if accepted.error != 0 {
+        val error = accepted.error
+        HttpConnectionResult.release(accepted)
+        return error
+    }
     val request = HttpConnection.read_request(accepted.connection, 16384, 1024, 5000)
     if request.error != 0 {
+        val error = request.error
+        HttpRequest.release(request)
         HttpConnection.close(accepted.connection)
-        return request.error
+        HttpConnectionResult.release(accepted)
+        return error
     }
     val response = Http.json_response(200, "\{\"status\":\"ok\"\}")
     val sent = HttpConnection.send_response(accepted.connection, response, 5000)
+    HttpResponse.release(response)
+    HttpRequest.release(request)
     HttpConnection.close(accepted.connection)
+    HttpConnectionResult.release(accepted)
     if sent != 0 { return sent }
     return 1
 }
 
 func fetch_one(url: String, result: Int) -> Int {
     val response = Http.get(url, 10000)
-    if response.error != 0 { return response.error }
-    if response.status != 200 { return -1 }
-    if response.body != "\{\"status\":\"ok\"\}" { return -2 }
-    return result
+    var outcome = result
+    if response.error != 0 { outcome = response.error }
+    if response.error == 0 and response.status != 200 { outcome = -1 }
+    if response.error == 0 and response.status == 200 and response.body != "\{\"status\":\"ok\"\}" { outcome = -2 }
+    HttpResponse.release(response)
+    return outcome
 }
 
 func main() {
     val listening = Http.listen("127.0.0.1", 0)
     if listening.error != 0 {
         println("listen-error {listening.error}")
+        HttpServerResult.release(listening)
         return
     }
     val port = HttpServer.port(listening.server)
@@ -58,7 +71,9 @@ func main() {
              (await c5) + (await c6) + (await c7) + (await c8)
     val sr = (await s1) + (await s2) + (await s3) + (await s4) +
              (await s5) + (await s6) + (await s7) + (await s8)
+    url.release()
     HttpServer.close(listening.server)
+    HttpServerResult.release(listening)
     if cr == 36 and sr == 8 {
         println("http concurrency ok: 8 clients")
     } else {

--- a/tests/integration/v4/7.5-stdlib/websocket_roundtrip.iron
+++ b/tests/integration/v4/7.5-stdlib/websocket_roundtrip.iron
@@ -3,33 +3,55 @@ import websocket
 
 func serve_one(server: HttpServer) -> Int {
     val accepted = HttpServer.accept(server, 5000)
-    if accepted.error != 0 { return accepted.error }
+    if accepted.error != 0 {
+        val error = accepted.error
+        HttpConnectionResult.release(accepted)
+        return error
+    }
     val request = HttpConnection.read_request(accepted.connection, 16384, 1024, 5000)
     if request.error != 0 {
+        val error = request.error
+        HttpRequest.release(request)
         HttpConnection.close(accepted.connection)
-        return request.error
+        HttpConnectionResult.release(accepted)
+        return error
     }
     val upgraded = HttpConnection.upgrade_websocket(accepted.connection, request, 4096, 5000)
     if upgraded.error != 0 {
+        val error = upgraded.error
+        WebSocketResult.release(upgraded)
+        HttpRequest.release(request)
         HttpConnection.close(accepted.connection)
-        return upgraded.error
+        HttpConnectionResult.release(accepted)
+        return error
     }
+    HttpRequest.release(request)
+    HttpConnectionResult.release(accepted)
     val message = WebSocket.receive(upgraded.socket, 5000)
     if message.error != 0 {
+        val error = message.error
+        WebSocketMessage.release(message)
         WebSocket.abort(upgraded.socket)
-        return message.error
+        WebSocketResult.release(upgraded)
+        return error
     }
     val sent = WebSocket.send_text(upgraded.socket, message.data, 5000)
+    WebSocketMessage.release(message)
     if sent != 0 {
         WebSocket.abort(upgraded.socket)
+        WebSocketResult.release(upgraded)
         return sent
     }
     val closed = WebSocket.receive(upgraded.socket, 5000)
     if closed.error != 0 or closed.kind != 8 {
+        WebSocketMessage.release(closed)
         WebSocket.abort(upgraded.socket)
+        WebSocketResult.release(upgraded)
         return -10
     }
+    WebSocketMessage.release(closed)
     WebSocket.abort(upgraded.socket)
+    WebSocketResult.release(upgraded)
     return 0
 }
 
@@ -37,16 +59,21 @@ func main() {
     val listening = Http.listen("127.0.0.1", 0)
     if listening.error != 0 {
         println("websocket failed: {listening.error}")
+        HttpServerResult.release(listening)
         return
     }
     val port = HttpServer.port(listening.server)
     val server_task = spawn("websocket-server") {
         return serve_one(listening.server)
     }
-    val connected = WebSocket.connect("ws://127.0.0.1:{port}/echo", "", 4096, 5000)
+    val url = "ws://127.0.0.1:{port}/echo"
+    val connected = WebSocket.connect(url, "", 4096, 5000)
+    url.release()
     if connected.error != 0 {
         println("websocket failed: {connected.error}")
+        WebSocketResult.release(connected)
         HttpServer.close(listening.server)
+        HttpServerResult.release(listening)
         return
     }
     val sent = WebSocket.send_text(connected.socket, "pure Iron websocket", 5000)
@@ -54,7 +81,11 @@ func main() {
     val closed = WebSocket.close(connected.socket, 1000, "done", 5000)
     val server_error = await server_task
     HttpServer.close(listening.server)
-    if sent == 0 and echoed.error == 0 and echoed.data == "pure Iron websocket" and closed == 0 and server_error == 0 {
+    val success = sent == 0 and echoed.error == 0 and echoed.data == "pure Iron websocket" and closed == 0 and server_error == 0
+    WebSocketMessage.release(echoed)
+    WebSocketResult.release(connected)
+    HttpServerResult.release(listening)
+    if success {
         println("websocket roundtrip ok")
     } else {
         println("websocket failed")

--- a/tests/lsp/invariant/test_phase7_audit.sh
+++ b/tests/lsp/invariant/test_phase7_audit.sh
@@ -114,7 +114,10 @@ if [[ ! -d "$BUILD_DIR" ]]; then
 else
     LABELS="$(ctest --test-dir "$BUILD_DIR" --print-labels 2>&1 || true)"
     for m in 1 2 3 4 5 6; do
-        if ! echo "$LABELS" | grep -q "phase-m${m}-invariant"; then
+        # Feed captured output directly to grep.  With `pipefail`, the old
+        # `echo "$LABELS" | grep -q ...` form could report failure when grep
+        # found an early match and echo then received SIGPIPE.
+        if ! grep -q "phase-m${m}-invariant" <<<"$LABELS"; then
             echo "MISSING CTest label: phase-m${m}-invariant" >&2
             FAIL=1
         fi
@@ -123,11 +126,11 @@ else
     # Parity tests must exist by name in the CTest graph. These are the
     # Core-Value enforcement tests and must never silently drop out.
     TESTS="$(ctest --test-dir "$BUILD_DIR" -N 2>&1 || true)"
-    if ! echo "$TESTS" | grep -qE "Test[ ]*#[0-9]+:[ ]*test_parity_ironc_lsp\b"; then
+    if ! grep -qE "Test[ ]*#[0-9]+:[ ]*test_parity_ironc_lsp\b" <<<"$TESTS"; then
         echo "MISSING CTest: test_parity_ironc_lsp" >&2
         FAIL=1
     fi
-    if ! echo "$TESTS" | grep -qE "test_parity_ironc_lsp_fmt\b"; then
+    if ! grep -qE "test_parity_ironc_lsp_fmt\b" <<<"$TESTS"; then
         echo "MISSING CTest: test_parity_ironc_lsp_fmt" >&2
         FAIL=1
     fi

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -335,7 +335,7 @@ endif()
 if(NOT WIN32)
     add_test(
         NAME test_http_iron_concurrency
-        COMMAND /bin/sh -c "set -e && d=\$(mktemp -d /tmp/iron_http_XXXXXX) && ${CMAKE_BINARY_DIR}/ironc build -o \"\$d/http_concurrency\" ${CMAKE_SOURCE_DIR}/tests/integration/v4/7.5-stdlib/http_concurrency.iron && actual=\$(\"\$d/http_concurrency\" 2>&1) && expected=\$(cat ${CMAKE_SOURCE_DIR}/tests/integration/v4/7.5-stdlib/http_concurrency.expected) && [ \"\$actual\" = \"\$expected\" ] && rm -rf \"\$d\""
+        COMMAND /bin/sh -c "set -e && d=\$(mktemp -d /tmp/iron_http_XXXXXX) && ASAN_OPTIONS=detect_leaks=0 ${CMAKE_BINARY_DIR}/ironc build -o \"\$d/http_concurrency\" ${CMAKE_SOURCE_DIR}/tests/integration/v4/7.5-stdlib/http_concurrency.iron && actual=\$(\"\$d/http_concurrency\" 2>&1) && expected=\$(cat ${CMAKE_SOURCE_DIR}/tests/integration/v4/7.5-stdlib/http_concurrency.expected) && [ \"\$actual\" = \"\$expected\" ] && rm -rf \"\$d\""
         WORKING_DIRECTORY /tmp
     )
     set_tests_properties(test_http_iron_concurrency PROPERTIES
@@ -343,7 +343,7 @@ if(NOT WIN32)
 
     add_test(
         NAME test_websocket_iron_roundtrip
-        COMMAND /bin/sh -c "set -e && d=\$(mktemp -d /tmp/iron_ws_XXXXXX) && ${CMAKE_BINARY_DIR}/ironc build -o \"\$d/websocket_roundtrip\" ${CMAKE_SOURCE_DIR}/tests/integration/v4/7.5-stdlib/websocket_roundtrip.iron && actual=\$(\"\$d/websocket_roundtrip\" 2>&1) && expected=\$(cat ${CMAKE_SOURCE_DIR}/tests/integration/v4/7.5-stdlib/websocket_roundtrip.expected) && [ \"\$actual\" = \"\$expected\" ] && rm -rf \"\$d\""
+        COMMAND /bin/sh -c "set -e && d=\$(mktemp -d /tmp/iron_ws_XXXXXX) && ASAN_OPTIONS=detect_leaks=0 ${CMAKE_BINARY_DIR}/ironc build -o \"\$d/websocket_roundtrip\" ${CMAKE_SOURCE_DIR}/tests/integration/v4/7.5-stdlib/websocket_roundtrip.iron && actual=\$(\"\$d/websocket_roundtrip\" 2>&1) && expected=\$(cat ${CMAKE_SOURCE_DIR}/tests/integration/v4/7.5-stdlib/websocket_roundtrip.expected) && [ \"\$actual\" = \"\$expected\" ] && rm -rf \"\$d\""
         WORKING_DIRECTORY /tmp
     )
     set_tests_properties(test_websocket_iron_roundtrip PROPERTIES
@@ -351,7 +351,7 @@ if(NOT WIN32)
 
     add_test(
         NAME test_file_operations_iron_roundtrip
-        COMMAND /bin/sh -c "set -e && d=\$(mktemp -d /tmp/iron_file_ops_XXXXXX) && ${CMAKE_BINARY_DIR}/ironc build -o \"\$d/file_operations_roundtrip\" ${CMAKE_SOURCE_DIR}/tests/integration/v4/7.5-stdlib/file_operations_roundtrip.iron && actual=\$(\"\$d/file_operations_roundtrip\" 2>&1) && expected=\$(cat ${CMAKE_SOURCE_DIR}/tests/integration/v4/7.5-stdlib/file_operations_roundtrip.expected) && [ \"\$actual\" = \"\$expected\" ] && rm -rf \"\$d\""
+        COMMAND /bin/sh -c "set -e && d=\$(mktemp -d /tmp/iron_file_ops_XXXXXX) && ASAN_OPTIONS=detect_leaks=0 ${CMAKE_BINARY_DIR}/ironc build -o \"\$d/file_operations_roundtrip\" ${CMAKE_SOURCE_DIR}/tests/integration/v4/7.5-stdlib/file_operations_roundtrip.iron && actual=\$(\"\$d/file_operations_roundtrip\" 2>&1) && expected=\$(cat ${CMAKE_SOURCE_DIR}/tests/integration/v4/7.5-stdlib/file_operations_roundtrip.expected) && [ \"\$actual\" = \"\$expected\" ] && rm -rf \"\$d\""
         WORKING_DIRECTORY /tmp
     )
     set_tests_properties(test_file_operations_iron_roundtrip PROPERTIES

--- a/tests/unit/lsp/obs/test_parent_watch_prctl.c
+++ b/tests/unit/lsp/obs/test_parent_watch_prctl.c
@@ -7,9 +7,12 @@
  * then sleeps. The parent of the test process exits; the child should
  * receive SIGTERM within ~5s and exit cleanly. We fork a test-parent
  * (A), which forks test-child (B) that installs the watcher and pauses.
- * A exits (orphaning B); B should be SIGTERM'd by the kernel via
- * PR_SET_PDEATHSIG. A final layer (the actual Unity test process)
- * waitpid()s B with a timeout.
+ * A waits until B confirms PR_SET_PDEATHSIG is installed, then exits
+ * (orphaning B); B should be SIGTERM'd by the kernel. The install
+ * handshake is essential: if A exits before B's first getppid(), Linux
+ * cannot distinguish that orphan from a process legitimately launched
+ * by a live container PID 1. A final layer (the actual Unity test
+ * process) observes B's result through a pipe.
  *
  * Unity layout:
  *   - Test 1: prctl install succeeds + marks installed()
@@ -56,10 +59,13 @@ static void test_e2e_parent_death_delivers_sigterm(void) {
      * "child" (C). C installs sigaction(SIGTERM) + parent_watch_init,
      * then pauses up to 5s. P1 then exits. Kernel should deliver SIGTERM
      * to C. C records that and exits 0; if no SIGTERM arrived, C exits 1.
-     * Unity process waitpid's P1, P1 waitpid's C, exit code of C is
-     * propagated via stderr pipe to Unity. */
+     * Unity waits for P1, then observes C's signal flag through the status
+     * pipe. P1 deliberately cannot wait for C because P1's exit is the
+     * parent-death event under test. */
     int status_pipe[2];
+    int ready_pipe[2];
     TEST_ASSERT_EQUAL_INT(0, pipe(status_pipe));
+    TEST_ASSERT_EQUAL_INT(0, pipe(ready_pipe));
 
     pid_t p1 = fork();
     TEST_ASSERT_MESSAGE(p1 >= 0, "fork p1");
@@ -67,17 +73,32 @@ static void test_e2e_parent_death_delivers_sigterm(void) {
         /* P1 */
         close(status_pipe[0]);
         pid_t c = fork();
+        if (c < 0) {
+            close(ready_pipe[0]);
+            close(ready_pipe[1]);
+            close(status_pipe[1]);
+            _exit(2);
+        }
         if (c == 0) {
             /* C: install watcher + sigterm trap + pause. Reset the
              * install latch because fork() inherited the Unity
              * process's already-installed state (prctl disposition
              * does NOT inherit across fork on Linux, though). */
+            close(ready_pipe[0]);
             ilsp_parent_watch_reset_for_testing();
             struct sigaction sa;
             memset(&sa, 0, sizeof(sa));
             sa.sa_handler = sigterm_flag;
             sigaction(SIGTERM, &sa, NULL);
             ilsp_parent_watch_init();
+
+            /* Do not let P1 exit until the watcher is installed. Without
+             * this handshake, a scheduler can orphan C before its first
+             * getppid(), making the test's intended parent unknowable. */
+            const unsigned char ready = 1;
+            ssize_t ready_written = write(ready_pipe[1], &ready, 1);
+            (void)ready_written;
+            close(ready_pipe[1]);
 
             /* Poll up to 5s for the flag; sleep(1) in a loop to let the
              * SIGTERM interrupt it. */
@@ -90,16 +111,25 @@ static void test_e2e_parent_death_delivers_sigterm(void) {
             close(status_pipe[1]);
             _exit(s_got_sigterm ? 0 : 1);
         }
-        /* P1: exit immediately so C becomes orphan. Do NOT waitpid(c) --
-         * our exit will orphan C, and the kernel delivers SIGTERM. Close
-         * the write-side in P1 so C is the only writer. */
+        /* P1: wait until C confirms the watcher is armed, then exit so C
+         * becomes orphaned. Do NOT waitpid(c): our exit is the event under
+         * test. Close the status write-side so C is the only writer. */
         close(status_pipe[1]);
-        _exit(0);
+        close(ready_pipe[1]);
+        unsigned char ready = 0;
+        ssize_t ready_read = read(ready_pipe[0], &ready, 1);
+        close(ready_pipe[0]);
+        _exit(ready_read == 1 && ready == 1 ? 0 : 2);
     }
     /* Unity: wait for P1 to exit. */
+    close(ready_pipe[0]);
+    close(ready_pipe[1]);
     close(status_pipe[1]);
     int s = 0;
     waitpid(p1, &s, 0);
+    TEST_ASSERT_TRUE_MESSAGE(WIFEXITED(s), "test parent exited normally");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, WEXITSTATUS(s),
+                                  "child watcher install handshake completed");
 
     /* Read the status byte (or EOF) from the pipe within ~8s. Use a
      * simple polling read with a deadline. */

--- a/tests/unit/test_cov_stdlib_io.c
+++ b/tests/unit/test_cov_stdlib_io.c
@@ -52,7 +52,7 @@ static char   s_sandbox[256];
 static size_t s_sandbox_len;
 
 static Iron_String make_str(const char *s) {
-    return iron_string_from_cstr(s, strlen(s));
+    return iron_string_from_literal(s, strlen(s));
 }
 
 /* mkpath joins the sandbox with a relative name and returns a new
@@ -60,7 +60,13 @@ static Iron_String make_str(const char *s) {
 static Iron_String mkpath(const char *rel) {
     char buf[512];
     snprintf(buf, sizeof(buf), "%s/%s", s_sandbox, rel);
-    return iron_string_from_cstr(buf, strlen(buf));
+    return iron_string_from_literal(buf, strlen(buf));
+}
+
+static void release_string_list(Iron_List_Iron_String *list) {
+    for (int64_t i = 0; i < list->count; i++)
+        iron_string_release(&list->items[i]);
+    Iron_List_Iron_String_free(list);
 }
 
 /* Best-effort teardown: unlink every file we might have written under
@@ -90,7 +96,7 @@ void setUp(void) {
     /* Create via the iron_io API — exercises Iron_io_create_dir on the
      * happy path and the already-exists branch in one shot. */
     rmdir(s_sandbox);  /* belt & braces from a crashed prior run */
-    Iron_String dir = iron_string_from_cstr(s_sandbox, s_sandbox_len);
+    Iron_String dir = iron_string_from_literal(s_sandbox, s_sandbox_len);
     Iron_Error err = Iron_io_create_dir(dir);
     TEST_ASSERT_EQUAL_INT(0, err.code);
     /* Second create_dir on the same path must hit the "already exists is
@@ -121,6 +127,7 @@ void test_io_read_file_inline_wrapper(void) {
      * has that will give iron_io.h any line coverage at all. */
     Iron_String content = Iron_io_read_file(path);
     TEST_ASSERT_EQUAL_STRING("hello inline wrapper", iron_string_cstr(&content));
+    iron_string_release(&content);
 }
 
 /* ── iron_io.c: read_bytes_result + read_bytes inline wrapper ────────────── */
@@ -141,6 +148,8 @@ void test_io_read_bytes_inline_wrapper(void) {
     /* Iron_io_read_bytes inline wrapper — gives iron_io.h coverage. */
     Iron_String bytes = Iron_io_read_bytes_legacy(path);
     TEST_ASSERT_EQUAL_size_t(sizeof(data), iron_string_byte_len(&bytes));
+    iron_string_release(&res.v0);
+    iron_string_release(&bytes);
 
     /* Write-file failure arm: write to an unwriteable path (/proc/self
      * on Linux) — skipped because it's platform-specific. The happy
@@ -171,6 +180,7 @@ void test_io_append_file(void) {
     Iron_String bad = make_str("/nonexistent/dir/x.txt");
     Iron_Error bad_err = Iron_io_append_file(bad, make_str("..."));
     TEST_ASSERT_NOT_EQUAL_INT(0, bad_err.code);
+    iron_string_release(&res.v0);
 }
 
 /* ── iron_io.c: list_files_result (the big one) ──────────────────────────── */
@@ -181,7 +191,7 @@ void test_io_list_files_happy_path(void) {
     Iron_io_write_file(mkpath("b.txt"), make_str("bravo"));
     Iron_io_write_file(mkpath("c.txt"), make_str("charlie"));
 
-    Iron_String dir = iron_string_from_cstr(s_sandbox, s_sandbox_len);
+    Iron_String dir = iron_string_from_literal(s_sandbox, s_sandbox_len);
     Iron_Result_String_Error res = Iron_io_list_files_result(dir);
     TEST_ASSERT_EQUAL_INT(0, res.v1.code);
 
@@ -196,6 +206,8 @@ void test_io_list_files_happy_path(void) {
     /* And the Iron_io_list_files inline wrapper for iron_io.h coverage. */
     Iron_String via_inline = Iron_io_list_files(dir);
     TEST_ASSERT_NOT_NULL(strstr(iron_string_cstr(&via_inline), "a.txt"));
+    iron_string_release(&res.v0);
+    iron_string_release(&via_inline);
 }
 
 void test_io_list_files_nonexistent(void) {
@@ -203,6 +215,7 @@ void test_io_list_files_nonexistent(void) {
     Iron_String bad = make_str("/tmp/iron_cov_io_totally_nonexistent_dir");
     Iron_Result_String_Error res = Iron_io_list_files_result(bad);
     TEST_ASSERT_NOT_EQUAL_INT(0, res.v1.code);
+    iron_string_release(&res.v0);
 }
 
 void test_io_list_files_buffer_growth(void) {
@@ -214,12 +227,13 @@ void test_io_list_files_buffer_growth(void) {
         Iron_io_write_file(mkpath(rel), make_str("x"));
     }
 
-    Iron_String dir = iron_string_from_cstr(s_sandbox, s_sandbox_len);
+    Iron_String dir = iron_string_from_literal(s_sandbox, s_sandbox_len);
     Iron_Result_String_Error res = Iron_io_list_files_result(dir);
     TEST_ASSERT_EQUAL_INT(0, res.v1.code);
     const char *out = iron_string_cstr(&res.v0);
     TEST_ASSERT_NOT_NULL(strstr(out, "grow_000.txt"));
     TEST_ASSERT_NOT_NULL(strstr(out, "grow_079.txt"));
+    iron_string_release(&res.v0);
 
     /* Tear down the extra files so sandbox_nuke can finish rmdir */
     for (int i = 0; i < 80; i++) {
@@ -241,6 +255,9 @@ void test_io_basename(void) {
     /* Trailing slash — basename returns empty (the char after `/`) */
     Iron_String r3 = Iron_io_basename(make_str("/tmp/foo/"));
     TEST_ASSERT_EQUAL_size_t(0, iron_string_byte_len(&r3));
+    iron_string_release(&r1);
+    iron_string_release(&r2);
+    iron_string_release(&r3);
 }
 
 void test_io_dirname(void) {
@@ -254,6 +271,9 @@ void test_io_dirname(void) {
     /* Slash at position 0 — returns "/" (the last == p branch) */
     Iron_String r3 = Iron_io_dirname(make_str("/root"));
     TEST_ASSERT_EQUAL_STRING("/", iron_string_cstr(&r3));
+    iron_string_release(&r1);
+    iron_string_release(&r2);
+    iron_string_release(&r3);
 }
 
 void test_io_join_path(void) {
@@ -265,6 +285,8 @@ void test_io_join_path(void) {
     Iron_String j2 = Iron_io_join_path(make_str("/tmp/foo///"),
                                         make_str("baz.iron"));
     TEST_ASSERT_EQUAL_STRING("/tmp/foo/baz.iron", iron_string_cstr(&j2));
+    iron_string_release(&j1);
+    iron_string_release(&j2);
 }
 
 void test_io_extension(void) {
@@ -281,11 +303,15 @@ void test_io_extension(void) {
     /* Multi-dot — keeps the last segment */
     Iron_String e4 = Iron_io_extension(make_str("/path/to/archive.tar.gz"));
     TEST_ASSERT_EQUAL_STRING("gz", iron_string_cstr(&e4));
+    iron_string_release(&e1);
+    iron_string_release(&e2);
+    iron_string_release(&e3);
+    iron_string_release(&e4);
 }
 
 void test_io_is_dir(void) {
     /* True path: the sandbox itself */
-    Iron_String dir = iron_string_from_cstr(s_sandbox, s_sandbox_len);
+    Iron_String dir = iron_string_from_literal(s_sandbox, s_sandbox_len);
     TEST_ASSERT_TRUE(Iron_io_is_dir(dir));
 
     /* False path: a plain file */
@@ -313,6 +339,8 @@ void test_io_read_lines(void) {
     Iron_String missing = mkpath("nope.txt");
     Iron_List_Iron_String empty = Iron_io_read_lines(missing);
     TEST_ASSERT_EQUAL_INT64(0, empty.count);
+    release_string_list(&lines);
+    release_string_list(&empty);
 }
 
 void test_io_bounded_binary_roundtrip(void) {
@@ -330,8 +358,10 @@ void test_io_bounded_binary_roundtrip(void) {
     TEST_ASSERT_EQUAL_MEMORY(payload, iron_string_cstr(&read.data), sizeof(payload));
 
     const uint8_t suffix[] = {0xa5, 0x00};
+    Iron_String suffix_data = iron_string_from_cstr(
+        (const char *)suffix, sizeof(suffix));
     Iron_FileWriteResult appended = Iron_io_append_bytes(
-        path, iron_string_from_cstr((const char *)suffix, sizeof(suffix)));
+        path, suffix_data);
     TEST_ASSERT_EQUAL_INT64(0, appended.error);
     TEST_ASSERT_EQUAL_INT64((int64_t)sizeof(suffix), appended.bytes);
     const uint8_t combined[] = {0x00, 0x01, 0x7f, 0x80, 0xfe, 0xff, 0xa5, 0x00};
@@ -345,6 +375,13 @@ void test_io_bounded_binary_roundtrip(void) {
     Iron_FileReadResult limited = Iron_io_read_bytes(path, 3);
     TEST_ASSERT_EQUAL_INT64(IRON_ERR_IO_TOO_LARGE, limited.error);
     TEST_ASSERT_EQUAL_size_t(0, iron_string_byte_len(&limited.data));
+    iron_string_release(&data);
+    iron_string_release(&suffix_data);
+    Iron_filewriteresult_release(written);
+    Iron_filereadresult_release(read);
+    Iron_filewriteresult_release(appended);
+    Iron_filereadresult_release(appended_read);
+    Iron_filereadresult_release(limited);
 }
 
 void test_io_text_append_info_copy_move(void) {
@@ -378,20 +415,37 @@ void test_io_text_append_info_copy_move(void) {
     TEST_ASSERT_EQUAL_STRING("alpha beta",
                              iron_string_cstr(&source_after_self_copy.data));
 
-    Iron_String sandbox = iron_string_from_cstr(s_sandbox, s_sandbox_len);
+    Iron_String sandbox = iron_string_from_literal(s_sandbox, s_sandbox_len);
     Iron_FileWriteResult directory_copy = Iron_io_copy_file(
         sandbox, copied_path, true);
     TEST_ASSERT_EQUAL_INT64(IRON_ERR_IO_IS_DIRECTORY, directory_copy.error);
 
     Iron_FileWriteResult self_move = Iron_io_move_file(source, source, true);
     TEST_ASSERT_EQUAL_INT64(IRON_ERR_IO_INVALID_ARGUMENT, self_move.error);
-    TEST_ASSERT_TRUE(Iron_io_file_info(source).exists);
+    Iron_FileInfo source_after_move = Iron_io_file_info(source);
+    TEST_ASSERT_TRUE(source_after_move.exists);
 
     Iron_String moved_path = mkpath("moved.bin");
     Iron_FileWriteResult moved = Iron_io_move_file(copied_path, moved_path, false);
     TEST_ASSERT_EQUAL_INT64(0, moved.error);
-    TEST_ASSERT_FALSE(Iron_io_file_info(copied_path).exists);
-    TEST_ASSERT_TRUE(Iron_io_file_info(moved_path).exists);
+    Iron_FileInfo copied_after_move = Iron_io_file_info(copied_path);
+    Iron_FileInfo moved_info = Iron_io_file_info(moved_path);
+    TEST_ASSERT_FALSE(copied_after_move.exists);
+    TEST_ASSERT_TRUE(moved_info.exists);
+    Iron_filewriteresult_release(first);
+    Iron_filewriteresult_release(second);
+    Iron_filereadresult_release(text);
+    Iron_fileinfo_release(info);
+    Iron_filewriteresult_release(copied);
+    Iron_filewriteresult_release(refused);
+    Iron_filewriteresult_release(self_copy);
+    Iron_filereadresult_release(source_after_self_copy);
+    Iron_filewriteresult_release(directory_copy);
+    Iron_filewriteresult_release(self_move);
+    Iron_fileinfo_release(source_after_move);
+    Iron_filewriteresult_release(moved);
+    Iron_fileinfo_release(copied_after_move);
+    Iron_fileinfo_release(moved_info);
 }
 
 typedef struct MoveRaceArgs {
@@ -460,14 +514,21 @@ void test_io_no_overwrite_move_is_atomic_against_creator(void) {
         if (args.moved.error == 0) {
             TEST_ASSERT_EQUAL_INT(EEXIST, args.create_error);
             TEST_ASSERT_EQUAL_STRING("source", iron_string_cstr(&final.data));
-            TEST_ASSERT_FALSE(Iron_io_file_info(source).exists);
+            Iron_FileInfo source_info = Iron_io_file_info(source);
+            TEST_ASSERT_FALSE(source_info.exists);
+            Iron_fileinfo_release(source_info);
         } else {
             TEST_ASSERT_EQUAL_INT64(IRON_ERR_IO_ALREADY_EXISTS,
                                     args.moved.error);
             TEST_ASSERT_EQUAL_INT(0, args.create_error);
             TEST_ASSERT_EQUAL_STRING("creator", iron_string_cstr(&final.data));
-            TEST_ASSERT_TRUE(Iron_io_file_info(source).exists);
+            Iron_FileInfo source_info = Iron_io_file_info(source);
+            TEST_ASSERT_TRUE(source_info.exists);
+            Iron_fileinfo_release(source_info);
         }
+        Iron_filewriteresult_release(seeded);
+        Iron_filewriteresult_release(args.moved);
+        Iron_filereadresult_release(final);
     }
 }
 

--- a/tests/unit/test_parser_recursion_guard.c
+++ b/tests/unit/test_parser_recursion_guard.c
@@ -6,12 +6,12 @@
  * Also asserts that moderate nesting (100 parens) parses cleanly — the
  * guard must not fire on any legitimate input.
  *
- * The guard lives in src/parser/parser.c as IRON_PARSER_MAX_DEPTH=1000
+ * The guard lives in src/parser/parser.c as IRON_PARSER_MAX_DEPTH=256
  * with a thin wrapper around iron_parse_expr_prec /
  * iron_parse_type_annotation / iron_parse_stmt / iron_parse_block /
  * iron_parse_decl. Every call through one of those entry points
  * increments p->recur_depth on entry and decrements on return; the
- * helper iron_parser_depth_exceeded trips at the ceiling, emits a
+ * helper iron_parser_depth_exceeded trips at the portable ceiling, emits a
  * diagnostic, and the caller returns an ErrorNode.
  */
 

--- a/tests/unit/test_runtime_string.c
+++ b/tests/unit/test_runtime_string.c
@@ -124,6 +124,27 @@ void test_intern_different_strings(void) {
     TEST_ASSERT_FALSE(iron_string_equals(&a, &b));
 }
 
+void test_string_release_consumes_owned_but_not_interned_storage(void) {
+    const char *owned_text =
+        "owned string storage longer than the SSO boundary";
+    Iron_String owned = iron_string_from_cstr(
+        owned_text, strlen(owned_text));
+    TEST_ASSERT_EQUAL_UINT8(1, owned.heap.flags & 0x01);
+    iron_string_release(&owned);
+    TEST_ASSERT_EQUAL_UINT8(0, owned.heap.flags & 0x01);
+    TEST_ASSERT_EQUAL_size_t(0, iron_string_byte_len(&owned));
+
+    const char *literal_text =
+        "interned string storage longer than the SSO boundary";
+    Iron_String literal = iron_string_from_literal(
+        literal_text, strlen(literal_text));
+    const char *interned_data = iron_string_cstr(&literal);
+    iron_string_release(&literal);
+    Iron_String again = iron_string_from_literal(
+        literal_text, strlen(literal_text));
+    TEST_ASSERT_EQUAL_PTR(interned_data, iron_string_cstr(&again));
+}
+
 /* ── Iron_Rc tests ───────────────────────────────────────────────────────── */
 /*
  * Phase 26 Plan 26-01: the pre-v4 Iron_Rc + Iron_Weak control-block-plus-value
@@ -214,6 +235,7 @@ int main(void) {
     RUN_TEST(test_concat_heap);
     RUN_TEST(test_intern_deduplicates);
     RUN_TEST(test_intern_different_strings);
+    RUN_TEST(test_string_release_consumes_owned_but_not_interned_storage);
 
     /* Iron_Rc + Iron_Weak: legacy v1.x API removed in Phase 26 Plan 26-01.
      * Coverage migrated to tests/unit/test_rc_layout.c +

--- a/tests/unit/test_stdlib_http.c
+++ b/tests/unit/test_stdlib_http.c
@@ -54,7 +54,7 @@ static int thread_join(HTTP_THREAD thread) { return pthread_join(thread, NULL); 
 void setUp(void) { iron_runtime_init(0, NULL); }
 void tearDown(void) { iron_runtime_shutdown(); }
 
-static Iron_String istr(const char *s) { return iron_string_from_cstr(s, strlen(s)); }
+static Iron_String istr(const char *s) { return iron_string_from_literal(s, strlen(s)); }
 
 static void assert_istr(const char *expected, Iron_String actual) {
     size_t len = iron_string_byte_len(&actual);
@@ -72,7 +72,11 @@ typedef struct ServerCase {
 static void *serve_one(void *arg) {
     ServerCase *ctx = (ServerCase *)arg;
     Iron_HttpConnectionResult accepted = Iron_httpserver_accept(ctx->server, 5000);
-    if (accepted.error) { ctx->error = accepted.error; return NULL; }
+    if (accepted.error) {
+        ctx->error = accepted.error;
+        Iron_httpconnectionresult_release(accepted);
+        return NULL;
+    }
     if (ctx->mode == 2 || ctx->mode == 3 || ctx->mode == 4 || ctx->mode == 5) {
         /* Consume the request before closing. Closing a TCP socket with unread
          * request bytes may produce a legal RST on Linux and make this raw
@@ -82,6 +86,7 @@ static void *serve_one(void *arg) {
         if (ctx->request.error) {
             ctx->error = ctx->request.error;
             Iron_httpconnection_close(accepted.connection);
+            Iron_httpconnectionresult_release(accepted);
             return NULL;
         }
         const char *wire;
@@ -102,6 +107,7 @@ static void *serve_one(void *arg) {
             socket, (const uint8_t *)wire, (int64_t)strlen(wire), 3000);
         ctx->error = wr.v1.code;
         Iron_httpconnection_close(accepted.connection);
+        Iron_httpconnectionresult_release(accepted);
         return NULL;
     }
     ctx->request = Iron_httpconnection_read_request(
@@ -109,6 +115,7 @@ static void *serve_one(void *arg) {
     if (ctx->request.error) {
         ctx->error = ctx->request.error;
         Iron_httpconnection_close(accepted.connection);
+        Iron_httpconnectionresult_release(accepted);
         return NULL;
     }
     Iron_HttpResponse response;
@@ -119,7 +126,9 @@ static void *serve_one(void *arg) {
         response = Iron_http_json_response(201, istr("{\"created\":true}"));
     }
     ctx->error = Iron_httpconnection_send_response(accepted.connection, response, 3000);
+    Iron_httpresponse_release(response);
     Iron_httpconnection_close(accepted.connection);
+    Iron_httpconnectionresult_release(accepted);
     return NULL;
 }
 
@@ -128,7 +137,9 @@ static Iron_HttpServer make_server(int64_t *port_out) {
     TEST_ASSERT_EQUAL_INT64(0, listen.error);
     *port_out = Iron_httpserver_port(listen.server);
     TEST_ASSERT_GREATER_THAN_INT64(0, *port_out);
-    return listen.server;
+    Iron_HttpServer server = listen.server;
+    Iron_httpserverresult_release(listen);
+    return server;
 }
 
 void test_http_response_models_and_header_lookup(void) {
@@ -144,15 +155,40 @@ void test_http_response_models_and_header_lookup(void) {
     Iron_HttpResponse malformed = Iron_http_response(200, istr("Broken Header"), istr(""));
     TEST_ASSERT_EQUAL_INT64(IRON_ERR_HTTP_INVALID_ARGUMENT, malformed.error);
 
+    const char *caller_headers =
+        "X-Caller-Owned: this header remains valid after response release";
+    const char *caller_body =
+        "this caller-owned response body is deliberately larger than SSO";
+    Iron_String dynamic_headers = iron_string_from_cstr(
+        caller_headers, strlen(caller_headers));
+    Iron_String dynamic_body = iron_string_from_cstr(
+        caller_body, strlen(caller_body));
+    Iron_HttpResponse cloned = Iron_http_response(
+        200, dynamic_headers, dynamic_body);
+    TEST_ASSERT_EQUAL_INT64(0, cloned.error);
+    Iron_httpresponse_release(cloned);
+    assert_istr(caller_headers, dynamic_headers);
+    assert_istr(caller_body, dynamic_body);
+
     Iron_HttpResponse file = Iron_http_file_response(
         200, istr(__FILE__), istr("text/plain"), 1024 * 1024);
     TEST_ASSERT_EQUAL_INT64(0, file.error);
     TEST_ASSERT_TRUE(strstr(iron_string_cstr(&file.body),
                             "test_http_response_models_and_header_lookup") != NULL);
-    assert_istr("text/plain", Iron_http_header(file.headers, istr("Content-Type")));
+    Iron_String file_type = Iron_http_header(file.headers, istr("Content-Type"));
+    assert_istr("text/plain", file_type);
     Iron_HttpResponse file_too_large = Iron_http_file_response(
         200, istr(__FILE__), istr("text/plain"), 1);
     TEST_ASSERT_EQUAL_INT64(IRON_ERR_HTTP_BODY_TOO_LARGE, file_too_large.error);
+    iron_string_release(&ct);
+    iron_string_release(&file_type);
+    Iron_httpresponse_release(response);
+    Iron_httpresponse_release(invalid);
+    Iron_httpresponse_release(malformed);
+    Iron_httpresponse_release(file);
+    Iron_httpresponse_release(file_too_large);
+    iron_string_release(&dynamic_headers);
+    iron_string_release(&dynamic_body);
 }
 
 void test_http_serves_webpage_and_client_gets_it(void) {
@@ -171,13 +207,17 @@ void test_http_serves_webpage_and_client_gets_it(void) {
     TEST_ASSERT_EQUAL_INT64(0, response.error);
     TEST_ASSERT_EQUAL_INT64(200, response.status);
     TEST_ASSERT_TRUE(strstr(iron_string_cstr(&response.body), "networking works") != NULL);
-    assert_istr("text/html; charset=utf-8",
-        Iron_http_header(response.headers, istr("Content-Type")));
+    Iron_String content_type = Iron_http_header(
+        response.headers, istr("Content-Type"));
+    assert_istr("text/html; charset=utf-8", content_type);
 
     TEST_ASSERT_EQUAL_INT(0, thread_join(thread));
     TEST_ASSERT_EQUAL_INT64(0, ctx.error);
     assert_istr("GET", ctx.request.method);
     assert_istr("/", ctx.request.path);
+    iron_string_release(&content_type);
+    Iron_httpresponse_release(response);
+    Iron_httprequest_release(ctx.request);
     Iron_httpserver_close(server);
 }
 
@@ -205,8 +245,12 @@ void test_http_rest_json_post_roundtrip(void) {
     assert_istr("/api/items", ctx.request.path);
     assert_istr("draft=1", ctx.request.query);
     assert_istr("{\"name\":\"anvil\"}", ctx.request.body);
-    assert_istr("application/json; charset=utf-8",
-        Iron_http_header(ctx.request.headers, istr("content-type")));
+    Iron_String content_type = Iron_http_header(
+        ctx.request.headers, istr("content-type"));
+    assert_istr("application/json; charset=utf-8", content_type);
+    iron_string_release(&content_type);
+    Iron_httpresponse_release(response);
+    Iron_httprequest_release(ctx.request);
     Iron_httpserver_close(server);
 }
 
@@ -227,6 +271,8 @@ void test_http_client_decodes_chunked_response(void) {
     assert_istr("Wikipedia", response.body);
     TEST_ASSERT_EQUAL_INT(0, thread_join(thread));
     TEST_ASSERT_EQUAL_INT64(0, ctx.error);
+    Iron_httpresponse_release(response);
+    Iron_httprequest_release(ctx.request);
     Iron_httpserver_close(server);
 }
 
@@ -247,6 +293,8 @@ void test_http_client_accepts_http_1_0_response(void) {
     assert_istr("legacy", response.body);
     TEST_ASSERT_EQUAL_INT(0, thread_join(thread));
     TEST_ASSERT_EQUAL_INT64(0, ctx.error);
+    Iron_httpresponse_release(response);
+    Iron_httprequest_release(ctx.request);
     Iron_httpserver_close(server);
 }
 
@@ -270,6 +318,8 @@ void test_http_client_head_does_not_read_declared_body(void) {
     TEST_ASSERT_EQUAL_INT(0, thread_join(thread));
     TEST_ASSERT_EQUAL_INT64(0, ctx.error);
     assert_istr("HEAD", ctx.request.method);
+    Iron_httpresponse_release(response);
+    Iron_httprequest_release(ctx.request);
     Iron_httpserver_close(server);
 }
 
@@ -287,8 +337,9 @@ void test_http_rejects_unsupported_and_ambiguous_inputs(void) {
     TEST_ASSERT_EQUAL_INT64(IRON_ERR_HTTP_INVALID_ARGUMENT, control.error);
 
     const char nul_url[] = "http://localhost/\0hidden";
-    Iron_HttpResponse embedded_nul = Iron_http_get(
-        iron_string_from_cstr(nul_url, sizeof(nul_url) - 1), 100);
+    Iron_String nul_input = iron_string_from_cstr(
+        nul_url, sizeof(nul_url) - 1);
+    Iron_HttpResponse embedded_nul = Iron_http_get(nul_input, 100);
     TEST_ASSERT_EQUAL_INT64(IRON_ERR_HTTP_BAD_URL, embedded_nul.error);
 
     Iron_HttpClientResult path_origin = Iron_httpclient_open(
@@ -311,6 +362,16 @@ void test_http_rejects_unsupported_and_ambiguous_inputs(void) {
         istr("http://example.com/"), istr(""), false, 1, 1000);
     TEST_ASSERT_EQUAL_INT64(0, trailing_slash.error);
     Iron_httpclient_close(trailing_slash.client);
+    iron_string_release(&nul_input);
+    Iron_httpresponse_release(unsupported);
+    Iron_httpresponse_release(framed);
+    Iron_httpresponse_release(control);
+    Iron_httpresponse_release(embedded_nul);
+    Iron_httpclientresult_release(path_origin);
+    Iron_httpclientresult_release(query_origin);
+    Iron_httpclientresult_release(fragment_origin);
+    Iron_httpclientresult_release(plain_tls_options);
+    Iron_httpclientresult_release(trailing_slash);
 }
 
 static Iron_HttpRequest parse_raw_request(const char *wire, int64_t max_body) {
@@ -328,6 +389,7 @@ static Iron_HttpRequest parse_raw_request(const char *wire, int64_t max_body) {
     Iron_HttpConnectionResult accepted = Iron_httpserver_accept(server, 2000);
     if (accepted.error != 0) {
         out.error = accepted.error;
+        Iron_httpconnectionresult_release(accepted);
         Iron_tcpsocket_close(dial.v0);
         Iron_httpserver_close(server);
         return out;
@@ -338,6 +400,7 @@ static Iron_HttpRequest parse_raw_request(const char *wire, int64_t max_body) {
     else out = Iron_httpconnection_read_request(
         accepted.connection, 16384, max_body, 2000);
     Iron_httpconnection_close(accepted.connection);
+    Iron_httpconnectionresult_release(accepted);
     Iron_tcpsocket_close(dial.v0);
     Iron_httpserver_close(server);
     return out;
@@ -384,6 +447,14 @@ void test_http_server_rejects_ambiguous_and_bounded_requests(void) {
         1024);
     TEST_ASSERT_EQUAL_INT64(0, explicit_close.error);
     TEST_ASSERT_FALSE(explicit_close.keep_alive);
+    Iron_httprequest_release(empty_host);
+    Iron_httprequest_release(ambiguous);
+    Iron_httprequest_release(bad_length);
+    Iron_httprequest_release(oversized);
+    Iron_httprequest_release(chunked);
+    Iron_httprequest_release(bad_trailer);
+    Iron_httprequest_release(legacy_keep_alive);
+    Iron_httprequest_release(explicit_close);
 }
 
 void test_http_client_rejects_transfer_coding_chain(void) {
@@ -401,6 +472,8 @@ void test_http_client_rejects_transfer_coding_chain(void) {
     TEST_ASSERT_EQUAL_INT64(IRON_ERR_HTTP_UNSUPPORTED_TRANSFER, response.error);
     TEST_ASSERT_EQUAL_INT(0, thread_join(thread));
     TEST_ASSERT_EQUAL_INT64(0, ctx.error);
+    Iron_httpresponse_release(response);
+    Iron_httprequest_release(ctx.request);
     Iron_httpserver_close(server);
 }
 
@@ -414,15 +487,22 @@ static void *stress_server(void *arg) {
     StressServer *ctx = (StressServer *)arg;
     for (int i = 0; i < STRESS_CLIENTS; i++) {
         Iron_HttpConnectionResult accepted = Iron_httpserver_accept(ctx->server, 10000);
-        if (accepted.error) { ctx->errors++; continue; }
+        if (accepted.error) {
+            ctx->errors++;
+            Iron_httpconnectionresult_release(accepted);
+            continue;
+        }
         Iron_HttpRequest request = Iron_httpconnection_read_request(
             accepted.connection, 16384, 1024, 5000);
         if (request.error) ctx->errors++;
         else {
             Iron_HttpResponse response = Iron_http_json_response(200, istr("{\"ok\":true}"));
             if (Iron_httpconnection_send_response(accepted.connection, response, 5000)) ctx->errors++;
+            Iron_httpresponse_release(response);
         }
+        Iron_httprequest_release(request);
         Iron_httpconnection_close(accepted.connection);
+        Iron_httpconnectionresult_release(accepted);
     }
     return NULL;
 }
@@ -432,6 +512,7 @@ static void *stress_client(void *arg) {
     StressClient *ctx = (StressClient *)arg;
     Iron_HttpResponse response = Iron_http_get(istr(ctx->url), 10000);
     ctx->error = response.error != 0 ? response.error : (response.status == 200 ? 0 : -1);
+    Iron_httpresponse_release(response);
     return NULL;
 }
 
@@ -470,20 +551,31 @@ typedef struct PersistentServer {
 static void *persistent_server(void *arg) {
     PersistentServer *ctx = (PersistentServer *)arg;
     Iron_HttpConnectionResult accepted = Iron_httpserver_accept(ctx->server, 5000);
-    if (accepted.error) { ctx->error = accepted.error; return NULL; }
+    if (accepted.error) {
+        ctx->error = accepted.error;
+        Iron_httpconnectionresult_release(accepted);
+        return NULL;
+    }
     ctx->accepts++;
     for (int i = 0; i < 3; i++) {
         Iron_HttpRequest request = Iron_httpconnection_read_request(
             accepted.connection, 16384, 1024, 3000);
-        if (request.error) { ctx->error = request.error; break; }
+        if (request.error) {
+            ctx->error = request.error;
+            Iron_httprequest_release(request);
+            break;
+        }
         ctx->requests++;
         int keep = i < 2;
+        Iron_HttpResponse response = Iron_http_text_response(200, request.path);
         ctx->error = Iron_httpconnection_send_response_keep_alive(
-            accepted.connection, Iron_http_text_response(200, request.path),
-            keep, 3000);
+            accepted.connection, response, keep, 3000);
+        Iron_httpresponse_release(response);
+        Iron_httprequest_release(request);
         if (ctx->error) break;
     }
     Iron_httpconnection_close(accepted.connection);
+    Iron_httpconnectionresult_release(accepted);
     return NULL;
 }
 
@@ -507,12 +599,14 @@ void test_http_client_reuses_one_connection_sequentially(void) {
         TEST_ASSERT_EQUAL_INT64(200, response.status);
         assert_istr(targets[i], response.body);
         TEST_ASSERT_EQUAL_INT(i < 2, response.keep_alive);
+        Iron_httpresponse_release(response);
     }
     Iron_httpclient_close(opened.client);
     TEST_ASSERT_EQUAL_INT(0, thread_join(thread));
     TEST_ASSERT_EQUAL_INT64(0, server.error);
     TEST_ASSERT_EQUAL_INT(1, server.accepts);
     TEST_ASSERT_EQUAL_INT(3, server.requests);
+    Iron_httpclientresult_release(opened);
     Iron_httpserver_close(server.server);
 }
 
@@ -521,17 +615,30 @@ static void *stale_retry_server(void *arg) {
     for (int connection_index = 0; connection_index < 2; connection_index++) {
         Iron_HttpConnectionResult accepted = Iron_httpserver_accept(
             ctx->server, 5000);
-        if (accepted.error) { ctx->error = accepted.error; return NULL; }
+        if (accepted.error) {
+            ctx->error = accepted.error;
+            Iron_httpconnectionresult_release(accepted);
+            return NULL;
+        }
         ctx->accepts++;
         Iron_HttpRequest request = Iron_httpconnection_read_request(
             accepted.connection, 16384, 1024, 3000);
-        if (request.error) { ctx->error = request.error; return NULL; }
+        if (request.error) {
+            ctx->error = request.error;
+            Iron_httprequest_release(request);
+            Iron_httpconnection_close(accepted.connection);
+            Iron_httpconnectionresult_release(accepted);
+            return NULL;
+        }
         ctx->requests++;
+        Iron_HttpResponse response = Iron_http_text_response(
+            200, istr(connection_index == 0 ? "first" : "retried"));
         ctx->error = Iron_httpconnection_send_response_keep_alive(
-            accepted.connection, Iron_http_text_response(
-                200, istr(connection_index == 0 ? "first" : "retried")),
-            connection_index == 0, 3000);
+            accepted.connection, response, connection_index == 0, 3000);
+        Iron_httpresponse_release(response);
+        Iron_httprequest_release(request);
         Iron_httpconnection_close(accepted.connection);
+        Iron_httpconnectionresult_release(accepted);
         if (ctx->error) return NULL;
     }
     return NULL;
@@ -562,22 +669,38 @@ void test_http_client_retries_stale_get_connection(void) {
     TEST_ASSERT_EQUAL_INT(0, thread_join(thread));
     TEST_ASSERT_EQUAL_INT64(0, server.error);
     TEST_ASSERT_EQUAL_INT(2, server.accepts);
+    Iron_httpresponse_release(first);
+    Iron_httpresponse_release(second);
+    Iron_httpclientresult_release(opened);
     Iron_httpserver_close(server.server);
 }
 
 static void *stale_post_server(void *arg) {
     PersistentServer *ctx = (PersistentServer *)arg;
     Iron_HttpConnectionResult accepted = Iron_httpserver_accept(ctx->server, 5000);
-    if (accepted.error) { ctx->error = accepted.error; return NULL; }
+    if (accepted.error) {
+        ctx->error = accepted.error;
+        Iron_httpconnectionresult_release(accepted);
+        return NULL;
+    }
     ctx->accepts++;
     Iron_HttpRequest request = Iron_httpconnection_read_request(
         accepted.connection, 16384, 1024, 3000);
-    if (request.error) { ctx->error = request.error; return NULL; }
+    if (request.error) {
+        ctx->error = request.error;
+        Iron_httprequest_release(request);
+        Iron_httpconnection_close(accepted.connection);
+        Iron_httpconnectionresult_release(accepted);
+        return NULL;
+    }
     ctx->requests++;
+    Iron_HttpResponse response = Iron_http_text_response(200, istr("primed"));
     ctx->error = Iron_httpconnection_send_response_keep_alive(
-        accepted.connection, Iron_http_text_response(200, istr("primed")),
-        true, 3000);
+        accepted.connection, response, true, 3000);
+    Iron_httpresponse_release(response);
+    Iron_httprequest_release(request);
     Iron_httpconnection_close(accepted.connection);
+    Iron_httpconnectionresult_release(accepted);
     if (ctx->error) return NULL;
 
     /* A POST attempted on the stale pooled socket must not be replayed onto a
@@ -589,6 +712,7 @@ static void *stale_post_server(void *arg) {
     } else if (replay.error != IRON_ERR_NET_TIMEOUT) {
         ctx->error = replay.error;
     }
+    Iron_httpconnectionresult_release(replay);
     return NULL;
 }
 
@@ -615,6 +739,9 @@ void test_http_client_does_not_retry_stale_post(void) {
     TEST_ASSERT_EQUAL_INT(0, thread_join(thread));
     TEST_ASSERT_EQUAL_INT64(0, server.error);
     TEST_ASSERT_EQUAL_INT(1, server.accepts);
+    Iron_httpresponse_release(primed);
+    Iron_httpresponse_release(post);
+    Iron_httpclientresult_release(opened);
     Iron_httpserver_close(server.server);
 }
 
@@ -645,9 +772,12 @@ static void *pool_handler(void *arg) {
 #endif
     Iron_HttpRequest request = Iron_httpconnection_read_request(
         handler->connection, 16384, 1024, 3000);
+    Iron_HttpResponse response = Iron_http_text_response(200, istr("pooled"));
     if (request.error || Iron_httpconnection_send_response(
-            handler->connection, Iron_http_text_response(200, istr("pooled")),
-            3000)) atomic_fetch_add(&handler->server->errors, 1);
+            handler->connection, response, 3000))
+        atomic_fetch_add(&handler->server->errors, 1);
+    Iron_httpresponse_release(response);
+    Iron_httprequest_release(request);
     Iron_httpconnection_close(handler->connection);
     atomic_fetch_sub(&handler->server->active, 1);
     return NULL;
@@ -661,14 +791,20 @@ static void *pool_server(void *arg) {
     for (int i = 0; i < POOLED_REQUESTS; i++) {
         Iron_HttpConnectionResult accepted = Iron_httpserver_accept(
             ctx->server, 10000);
-        if (accepted.error) { atomic_fetch_add(&ctx->errors, 1); break; }
+        if (accepted.error) {
+            atomic_fetch_add(&ctx->errors, 1);
+            Iron_httpconnectionresult_release(accepted);
+            break;
+        }
         cases[i].server = ctx;
         cases[i].connection = accepted.connection;
         if (thread_start(&handlers[i], pool_handler, &cases[i]) != 0) {
             atomic_fetch_add(&ctx->errors, 1);
             Iron_httpconnection_close(accepted.connection);
+            Iron_httpconnectionresult_release(accepted);
             break;
         }
+        Iron_httpconnectionresult_release(accepted);
         started++;
     }
     for (int i = 0; i < started; i++)
@@ -687,6 +823,7 @@ static void *pool_client(void *arg) {
         test->client, istr("GET"), istr("/pool"), istr(""), istr(""),
         1024, 10000);
     test->error = response.error;
+    Iron_httpresponse_release(response);
     return NULL;
 }
 
@@ -723,6 +860,7 @@ void test_http_client_pool_bounds_concurrent_connections(void) {
     TEST_ASSERT_EQUAL_INT(0, atomic_load(&server.errors));
     TEST_ASSERT_LESS_OR_EQUAL_INT(POOL_LIMIT, atomic_load(&server.peak));
     TEST_ASSERT_GREATER_THAN_INT(1, atomic_load(&server.peak));
+    Iron_httpclientresult_release(opened);
     Iron_httpserver_close(server.server);
 }
 

--- a/tests/unit/test_stdlib_http.c
+++ b/tests/unit/test_stdlib_http.c
@@ -751,6 +751,7 @@ typedef struct PoolServer {
     atomic_int active;
     atomic_int peak;
     atomic_int errors;
+    atomic_int release_first_wave;
 } PoolServer;
 
 typedef struct PoolHandler {
@@ -758,18 +759,27 @@ typedef struct PoolHandler {
     Iron_HttpConnection connection;
 } PoolHandler;
 
+static void pool_pause_one_millisecond(void) {
+#ifdef _WIN32
+    Sleep(1);
+#else
+    struct timespec pause = { 0, 1000 * 1000 };
+    nanosleep(&pause, NULL);
+#endif
+}
+
 static void *pool_handler(void *arg) {
     PoolHandler *handler = (PoolHandler *)arg;
     int active = atomic_fetch_add(&handler->server->active, 1) + 1;
     int peak = atomic_load(&handler->server->peak);
     while (peak < active && !atomic_compare_exchange_weak(
         &handler->server->peak, &peak, active)) { }
-#ifdef _WIN32
-    Sleep(40);
-#else
-    struct timespec pause = { 0, 40 * 1000 * 1000 };
-    nanosleep(&pause, NULL);
-#endif
+    /* Hold the first admitted requests so no client slot can be released.
+     * The test can then observe the admission bound without counting the
+     * server-side close/bookkeeping interval as an extra connection. */
+    while (!atomic_load_explicit(&handler->server->release_first_wave,
+                                 memory_order_acquire))
+        pool_pause_one_millisecond();
     Iron_HttpRequest request = Iron_httpconnection_read_request(
         handler->connection, 16384, 1024, 3000);
     Iron_HttpResponse response = Iron_http_text_response(200, istr("pooled"));
@@ -835,6 +845,7 @@ void test_http_client_pool_bounds_concurrent_connections(void) {
     atomic_init(&server.active, 0);
     atomic_init(&server.peak, 0);
     atomic_init(&server.errors, 0);
+    atomic_init(&server.release_first_wave, 0);
     HTTP_THREAD server_thread;
     TEST_ASSERT_EQUAL_INT(0, thread_start(&server_thread, pool_server, &server));
     char origin[128];
@@ -851,6 +862,18 @@ void test_http_client_pool_bounds_concurrent_connections(void) {
         TEST_ASSERT_EQUAL_INT(0, thread_start(
             &threads[i], pool_client, &clients[i]));
     }
+    /* Wait for the four slots to fill, then leave them blocked briefly. If
+     * the pool admits a fifth request, the server peak records it before the
+     * barrier is released. */
+    for (int i = 0; i < 3000 &&
+         atomic_load_explicit(&server.active, memory_order_acquire) <
+             POOL_LIMIT; i++)
+        pool_pause_one_millisecond();
+    for (int i = 0; i < 100; i++) pool_pause_one_millisecond();
+    int first_wave_peak = atomic_load_explicit(&server.peak,
+                                                memory_order_acquire);
+    atomic_store_explicit(&server.release_first_wave, 1,
+                          memory_order_release);
     for (int i = 0; i < POOLED_REQUESTS; i++) {
         TEST_ASSERT_EQUAL_INT(0, thread_join(threads[i]));
         TEST_ASSERT_EQUAL_INT64(0, clients[i].error);
@@ -858,8 +881,7 @@ void test_http_client_pool_bounds_concurrent_connections(void) {
     Iron_httpclient_close(opened.client);
     TEST_ASSERT_EQUAL_INT(0, thread_join(server_thread));
     TEST_ASSERT_EQUAL_INT(0, atomic_load(&server.errors));
-    TEST_ASSERT_LESS_OR_EQUAL_INT(POOL_LIMIT, atomic_load(&server.peak));
-    TEST_ASSERT_GREATER_THAN_INT(1, atomic_load(&server.peak));
+    TEST_ASSERT_EQUAL_INT(POOL_LIMIT, first_wave_peak);
     Iron_httpclientresult_release(opened);
     Iron_httpserver_close(server.server);
 }

--- a/tests/unit/test_stdlib_tls.c
+++ b/tests/unit/test_stdlib_tls.c
@@ -50,7 +50,7 @@ static const char *private_key_path;
 enum { WSS_WRITERS = 24 };
 
 static Iron_String istr(const char *text) {
-    return iron_string_from_cstr(text, strlen(text));
+    return iron_string_from_literal(text, strlen(text));
 }
 
 void setUp(void) { iron_runtime_init(0, NULL); }
@@ -93,6 +93,7 @@ static void *serve_tls_once(void *pointer) {
     Iron_HttpsConnectionResult accepted = Iron_httpsserver_accept(test->server, 5000);
     if (accepted.error != 0) {
         test->error = accepted.error;
+        Iron_httpsconnectionresult_release(accepted);
         return NULL;
     }
     if (test->expect_http) {
@@ -106,77 +107,108 @@ static void *serve_tls_once(void *pointer) {
                 200, istr("secure iron"));
             test->error = Iron_httpsconnection_send_response(
                 accepted.connection, response, 5000);
+            Iron_httpresponse_release(response);
         }
     }
     Iron_httpsconnection_close(accepted.connection);
+    Iron_httpsconnectionresult_release(accepted);
     return NULL;
 }
 
 static void *serve_wss_once(void *pointer) {
     TlsServerCase *test = (TlsServerCase *)pointer;
     Iron_HttpsConnectionResult accepted = Iron_httpsserver_accept(test->server, 5000);
-    if (accepted.error != 0) { test->error = accepted.error; return NULL; }
+    if (accepted.error != 0) {
+        test->error = accepted.error;
+        Iron_httpsconnectionresult_release(accepted);
+        return NULL;
+    }
     Iron_HttpRequest request = Iron_httpsconnection_read_request(
         accepted.connection, 16384, 1024, 5000);
     if (request.error != 0) {
         test->error = request.error;
+        Iron_httprequest_release(request);
         Iron_httpsconnection_close(accepted.connection);
+        Iron_httpsconnectionresult_release(accepted);
         return NULL;
     }
     Iron_WebSocketResult upgraded = Iron_httpsconnection_upgrade_websocket(
         accepted.connection, request, 1024, 5000);
     if (upgraded.error != 0) {
         test->error = upgraded.error;
+        Iron_websocketresult_release(upgraded);
+        Iron_httprequest_release(request);
         Iron_httpsconnection_close(accepted.connection);
+        Iron_httpsconnectionresult_release(accepted);
         return NULL;
     }
+    Iron_httprequest_release(request);
+    Iron_httpsconnectionresult_release(accepted);
     Iron_WebSocketMessage message = Iron_websocket_receive(upgraded.socket, 5000);
     if (message.error != 0 || message.kind != IRON_WEBSOCKET_TEXT) {
         test->error = message.error ? message.error : -1;
     } else {
         test->error = Iron_websocket_send_text(upgraded.socket, message.data, 5000);
     }
+    Iron_websocketmessage_release(message);
     if (!test->error) {
         Iron_WebSocketMessage close = Iron_websocket_receive(upgraded.socket, 5000);
         if (close.error != 0 || close.kind != IRON_WEBSOCKET_CLOSE)
             test->error = close.error ? close.error : -2;
+        Iron_websocketmessage_release(close);
     }
     Iron_websocket_abort(upgraded.socket);
+    Iron_websocketresult_release(upgraded);
     return NULL;
 }
 
 static void *serve_wss_concurrent(void *pointer) {
     TlsServerCase *test = (TlsServerCase *)pointer;
     Iron_HttpsConnectionResult accepted = Iron_httpsserver_accept(test->server, 5000);
-    if (accepted.error != 0) { test->error = accepted.error; return NULL; }
+    if (accepted.error != 0) {
+        test->error = accepted.error;
+        Iron_httpsconnectionresult_release(accepted);
+        return NULL;
+    }
     Iron_HttpRequest request = Iron_httpsconnection_read_request(
         accepted.connection, 16384, 1024, 5000);
     if (request.error != 0) {
         test->error = request.error;
+        Iron_httprequest_release(request);
         Iron_httpsconnection_close(accepted.connection);
+        Iron_httpsconnectionresult_release(accepted);
         return NULL;
     }
     Iron_WebSocketResult upgraded = Iron_httpsconnection_upgrade_websocket(
         accepted.connection, request, 1024, 5000);
     if (upgraded.error != 0) {
         test->error = upgraded.error;
+        Iron_websocketresult_release(upgraded);
+        Iron_httprequest_release(request);
         Iron_httpsconnection_close(accepted.connection);
+        Iron_httpsconnectionresult_release(accepted);
         return NULL;
     }
+    Iron_httprequest_release(request);
+    Iron_httpsconnectionresult_release(accepted);
     for (int i = 0; i < WSS_WRITERS && test->error == 0; i++) {
         Iron_WebSocketMessage message = Iron_websocket_receive(upgraded.socket, 5000);
         if (message.error != 0 || message.kind != IRON_WEBSOCKET_TEXT) {
             test->error = message.error ? message.error : -10;
+            Iron_websocketmessage_release(message);
             break;
         }
         test->error = Iron_websocket_send_text(upgraded.socket, message.data, 5000);
+        Iron_websocketmessage_release(message);
     }
     if (test->error == 0) {
         Iron_WebSocketMessage close = Iron_websocket_receive(upgraded.socket, 5000);
         if (close.error != 0 || close.kind != IRON_WEBSOCKET_CLOSE)
             test->error = close.error ? close.error : -11;
+        Iron_websocketmessage_release(close);
     }
     Iron_websocket_abort(upgraded.socket);
+    Iron_websocketresult_release(upgraded);
     return NULL;
 }
 
@@ -204,8 +236,10 @@ static void *receive_wss_echoes(void *pointer) {
         Iron_WebSocketMessage message = Iron_websocket_receive(reader->socket, 5000);
         if (message.error != 0 || message.kind != IRON_WEBSOCKET_TEXT) {
             reader->error = message.error ? message.error : -20;
+            Iron_websocketmessage_release(message);
             return NULL;
         }
+        Iron_websocketmessage_release(message);
     }
     return NULL;
 }
@@ -216,7 +250,9 @@ static Iron_HttpsServer make_tls_server(int64_t *port) {
     TEST_ASSERT_EQUAL_INT64(0, result.error);
     *port = Iron_httpsserver_port(result.server);
     TEST_ASSERT_GREATER_THAN_INT64(0, *port);
-    return result.server;
+    Iron_HttpsServer server = result.server;
+    Iron_httpsserverresult_release(result);
+    return server;
 }
 
 static void start_case(TlsServerCase *test, TLS_THREAD *thread, int expect_http,
@@ -246,6 +282,8 @@ void test_https_verified_custom_ca_roundtrip(void) {
     TEST_ASSERT_EQUAL_STRING("POST", iron_string_cstr(&server.request.method));
     TEST_ASSERT_EQUAL_STRING("{\"secure\":true}",
                              iron_string_cstr(&server.request.body));
+    Iron_httpresponse_release(response);
+    Iron_httprequest_release(server.request);
     Iron_httpsserver_close(server.server);
 }
 
@@ -262,6 +300,7 @@ void test_https_default_rejects_untrusted_certificate(void) {
     TEST_ASSERT_TRUE(server.error == IRON_ERR_TLS_HANDSHAKE ||
                      server.error == IRON_ERR_TLS_CLOSED ||
                      server.error == IRON_ERR_TLS_IO);
+    Iron_httpresponse_release(response);
     Iron_httpsserver_close(server.server);
 }
 
@@ -276,6 +315,7 @@ void test_https_rejects_hostname_mismatch(void) {
         istr(url), istr(certificate_path), 5000);
     TEST_ASSERT_EQUAL_INT64(IRON_ERR_TLS_VERIFY, response.error);
     TEST_ASSERT_EQUAL_INT(0, thread_join(thread));
+    Iron_httpresponse_release(response);
     Iron_httpsserver_close(server.server);
 }
 
@@ -291,6 +331,8 @@ void test_https_explicit_insecure_mode_roundtrip(void) {
     TEST_ASSERT_EQUAL_INT64(200, response.status);
     TEST_ASSERT_EQUAL_INT(0, thread_join(thread));
     TEST_ASSERT_EQUAL_INT64(0, server.error);
+    Iron_httpresponse_release(response);
+    Iron_httprequest_release(server.request);
     Iron_httpsserver_close(server.server);
 }
 
@@ -300,6 +342,7 @@ void test_https_server_rejects_missing_certificate(void) {
         istr("/definitely/missing/key.pem"));
     TEST_ASSERT_EQUAL_INT64(IRON_ERR_TLS_CERTIFICATE, result.error);
     TEST_ASSERT_EQUAL_INT64(-1, result.server.fd);
+    Iron_httpsserverresult_release(result);
 }
 
 void test_https_stalled_tcp_does_not_block_next_client(void) {
@@ -320,6 +363,7 @@ void test_https_stalled_tcp_does_not_block_next_client(void) {
     TLS_THREAD slow_thread;
     TEST_ASSERT_EQUAL_INT(0, thread_start(
         &slow_thread, handshake_pending, &slow));
+    Iron_httpspendingconnectionresult_release(stalled);
 
     char url[128];
     snprintf(url, sizeof(url), "https://localhost:%lld/admitted",
@@ -343,20 +387,26 @@ void test_https_stalled_tcp_does_not_block_next_client(void) {
         connection.connection, 16384, 1024, 3000);
     TEST_ASSERT_EQUAL_INT64(0, request.error);
     TEST_ASSERT_EQUAL_STRING("/admitted", iron_string_cstr(&request.path));
+    Iron_HttpResponse response = Iron_http_text_response(200, istr("admitted"));
     TEST_ASSERT_EQUAL_INT64(0, Iron_httpsconnection_send_response(
-        connection.connection, Iron_http_text_response(200, istr("admitted")),
-        3000));
+        connection.connection, response, 3000));
+    Iron_httpresponse_release(response);
+    Iron_httprequest_release(request);
     Iron_httpsconnection_close(connection.connection);
+    Iron_httpsconnectionresult_release(connection);
+    Iron_httpspendingconnectionresult_release(admitted);
 
     TEST_ASSERT_EQUAL_INT(0, thread_join(client_thread));
     TEST_ASSERT_EQUAL_INT64(0, client.response.error);
     TEST_ASSERT_EQUAL_INT64(200, client.response.status);
     TEST_ASSERT_EQUAL_STRING("admitted",
                              iron_string_cstr(&client.response.body));
+    Iron_httpresponse_release(client.response);
 
     Iron_tcpsocket_close(raw.v0);
     TEST_ASSERT_EQUAL_INT(0, thread_join(slow_thread));
     TEST_ASSERT_NOT_EQUAL(0, slow.result.error);
+    Iron_httpsconnectionresult_release(slow.result);
 }
 
 void test_wss_verified_upgrade_and_message_roundtrip(void) {
@@ -382,6 +432,8 @@ void test_wss_verified_upgrade_and_message_roundtrip(void) {
         connected.socket, 1000, istr("done"), 5000));
     TEST_ASSERT_EQUAL_INT(0, thread_join(thread));
     TEST_ASSERT_EQUAL_INT64(0, server.error);
+    Iron_websocketmessage_release(echoed);
+    Iron_websocketresult_release(connected);
     Iron_httpsserver_close(server.server);
 }
 
@@ -425,6 +477,7 @@ void test_wss_concurrent_reader_and_writers(void) {
         connected.socket, 1000, istr("concurrency done"), 5000));
     TEST_ASSERT_EQUAL_INT(0, thread_join(server_thread));
     TEST_ASSERT_EQUAL_INT64(0, server.error);
+    Iron_websocketresult_release(connected);
     Iron_httpsserver_close(server.server);
 }
 

--- a/tests/unit/test_stdlib_websocket.c
+++ b/tests/unit/test_stdlib_websocket.c
@@ -47,7 +47,9 @@ static int thread_join(WS_THREAD thread) { return pthread_join(thread, NULL); }
 static Iron_String istrn(const void *bytes, size_t length) {
     return iron_string_from_cstr((const char *)bytes, length);
 }
-static Iron_String istr(const char *text) { return istrn(text, strlen(text)); }
+static Iron_String istr(const char *text) {
+    return iron_string_from_literal(text, strlen(text));
+}
 
 void setUp(void) { iron_runtime_init(0, NULL); }
 void tearDown(void) { iron_runtime_shutdown(); }
@@ -72,12 +74,19 @@ enum { WS_WRITERS = 24 };
 static int server_upgrade(WsServerCase *test, Iron_WebSocket *socket,
                           int64_t max_message) {
     Iron_HttpConnectionResult accepted = Iron_httpserver_accept(test->server, 5000);
-    if (accepted.error != 0) return (int)accepted.error;
+    if (accepted.error != 0) {
+        int error = (int)accepted.error;
+        Iron_httpconnectionresult_release(accepted);
+        return error;
+    }
     Iron_HttpRequest request = Iron_httpconnection_read_request(
         accepted.connection, 16384, 1024, 5000);
     if (request.error != 0) {
+        int error = (int)request.error;
+        Iron_httprequest_release(request);
         Iron_httpconnection_close(accepted.connection);
-        return (int)request.error;
+        Iron_httpconnectionresult_release(accepted);
+        return error;
     }
     Iron_WebSocketResult upgraded = test->mode == 7 || test->mode == 8
         ? Iron_httpconnection_upgrade_websocket_protocol(
@@ -87,12 +96,27 @@ static int server_upgrade(WsServerCase *test, Iron_WebSocket *socket,
         : Iron_httpconnection_upgrade_websocket(
             accepted.connection, request, max_message, 5000);
     if (upgraded.error != 0) {
+        int error = (int)upgraded.error;
+        Iron_websocketresult_release(upgraded);
+        Iron_httprequest_release(request);
         Iron_httpconnection_close(accepted.connection);
-        return (int)upgraded.error;
+        Iron_httpconnectionresult_release(accepted);
+        return error;
     }
     *socket = upgraded.socket;
-    test->protocol = upgraded.protocol;
+    test->protocol = iron_string_from_cstr(
+        iron_string_cstr(&upgraded.protocol),
+        iron_string_byte_len(&upgraded.protocol));
+    Iron_websocketresult_release(upgraded);
+    Iron_httprequest_release(request);
+    Iron_httpconnectionresult_release(accepted);
     return 0;
+}
+
+static void release_server_case(WsServerCase *test) {
+    iron_string_release(&test->text);
+    iron_string_release(&test->binary);
+    iron_string_release(&test->protocol);
 }
 
 static void *serve_websocket(void *pointer) {
@@ -105,34 +129,43 @@ static void *serve_websocket(void *pointer) {
         Iron_WebSocketMessage text = Iron_websocket_receive(socket, 5000);
         if (text.error || text.kind != IRON_WEBSOCKET_TEXT) {
             test->error = text.error ? text.error : -1;
+            Iron_websocketmessage_release(text);
             Iron_websocket_abort(socket);
             return NULL;
         }
-        test->text = text.data;
+        test->text = iron_string_from_cstr(
+            iron_string_cstr(&text.data), iron_string_byte_len(&text.data));
         test->error = Iron_websocket_send_text(socket, text.data, 5000);
+        Iron_websocketmessage_release(text);
         if (test->error) { Iron_websocket_abort(socket); return NULL; }
 
         Iron_WebSocketMessage binary = Iron_websocket_receive(socket, 5000);
         if (binary.error || binary.kind != IRON_WEBSOCKET_BINARY) {
             test->error = binary.error ? binary.error : -2;
+            Iron_websocketmessage_release(binary);
             Iron_websocket_abort(socket);
             return NULL;
         }
-        test->binary = binary.data;
+        test->binary = iron_string_from_cstr(
+            iron_string_cstr(&binary.data), iron_string_byte_len(&binary.data));
         test->error = Iron_websocket_send_bytes(socket, binary.data, 5000);
+        Iron_websocketmessage_release(binary);
         if (test->error) { Iron_websocket_abort(socket); return NULL; }
 
         Iron_WebSocketMessage ping = Iron_websocket_receive(socket, 5000);
         if (ping.error || ping.kind != IRON_WEBSOCKET_PING) {
             test->error = ping.error ? ping.error : -3;
+            Iron_websocketmessage_release(ping);
             Iron_websocket_abort(socket);
             return NULL;
         }
+        Iron_websocketmessage_release(ping);
         Iron_WebSocketMessage close = Iron_websocket_receive(socket, 5000);
         if (close.error || close.kind != IRON_WEBSOCKET_CLOSE ||
             close.close_code != 1000) {
             test->error = close.error ? close.error : -4;
         }
+        Iron_websocketmessage_release(close);
         Iron_websocket_abort(socket);
         return NULL;
     }
@@ -140,24 +173,30 @@ static void *serve_websocket(void *pointer) {
         Iron_WebSocketMessage ping = Iron_websocket_receive(socket, 5000);
         if (ping.error || ping.kind != IRON_WEBSOCKET_PING)
             test->error = ping.error ? ping.error : -10;
+        Iron_websocketmessage_release(ping);
         if (!test->error) {
             Iron_WebSocketMessage text = Iron_websocket_receive(socket, 5000);
             if (text.error || text.kind != IRON_WEBSOCKET_TEXT)
                 test->error = text.error ? text.error : -11;
-            else test->text = text.data;
+            else test->text = iron_string_from_cstr(
+                iron_string_cstr(&text.data), iron_string_byte_len(&text.data));
+            Iron_websocketmessage_release(text);
         }
     } else if (test->mode == 4) {
         for (int i = 0; i < WS_WRITERS; i++) {
             Iron_WebSocketMessage message = Iron_websocket_receive(socket, 5000);
             if (message.error != 0 || message.kind != IRON_WEBSOCKET_TEXT) {
                 test->error = message.error ? message.error : -20;
+                Iron_websocketmessage_release(message);
                 break;
             }
+            Iron_websocketmessage_release(message);
         }
         if (!test->error) {
             Iron_WebSocketMessage close = Iron_websocket_receive(socket, 5000);
             if (close.error != 0 || close.kind != IRON_WEBSOCKET_CLOSE)
                 test->error = close.error ? close.error : -21;
+            Iron_websocketmessage_release(close);
         }
     } else if (test->mode == 5) {
         Iron_WebSocketMessage small = Iron_websocket_receive(socket, 5000);
@@ -166,25 +205,32 @@ static void *serve_websocket(void *pointer) {
         } else {
             test->error = Iron_websocket_send_bytes(socket, small.data, 5000);
         }
+        Iron_websocketmessage_release(small);
         Iron_WebSocketMessage message = Iron_websocket_receive(socket, 5000);
         if (message.error != 0 || message.kind != IRON_WEBSOCKET_BINARY) {
             test->error = message.error ? message.error : -30;
         } else {
-            test->binary = message.data;
+            test->binary = iron_string_from_cstr(
+                iron_string_cstr(&message.data),
+                iron_string_byte_len(&message.data));
             test->error = Iron_websocket_send_bytes(socket, message.data, 5000);
         }
+        Iron_websocketmessage_release(message);
         if (!test->error) {
             Iron_WebSocketMessage close = Iron_websocket_receive(socket, 5000);
             if (close.error != 0 || close.kind != IRON_WEBSOCKET_CLOSE)
                 test->error = close.error ? close.error : -31;
+            Iron_websocketmessage_release(close);
         }
     } else if (test->mode == 7) {
         Iron_WebSocketMessage close = Iron_websocket_receive(socket, 5000);
         if (close.error != 0 || close.kind != IRON_WEBSOCKET_CLOSE)
             test->error = close.error ? close.error : -40;
+        Iron_websocketmessage_release(close);
     } else {
         Iron_WebSocketMessage message = Iron_websocket_receive(socket, 5000);
         test->error = message.error;
+        Iron_websocketmessage_release(message);
     }
     Iron_websocket_abort(socket);
     return NULL;
@@ -209,7 +255,9 @@ static Iron_HttpServer make_server(int64_t *port) {
     TEST_ASSERT_EQUAL_INT64(0, result.error);
     *port = Iron_httpserver_port(result.server);
     TEST_ASSERT_GREATER_THAN_INT64(0, *port);
-    return result.server;
+    Iron_HttpServer server = result.server;
+    Iron_httpserverresult_release(result);
+    return server;
 }
 
 static void start_server_case(WsServerCase *test, WS_THREAD *thread,
@@ -239,8 +287,10 @@ void test_websocket_client_server_text_binary_ping_close(void) {
     assert_bytes("hello websocket", 15, text.data);
 
     const uint8_t binary_bytes[] = { 0x00, 0x01, 0x7f, 0x80, 0xfe, 0xff };
+    Iron_String outbound_binary = istrn(binary_bytes, sizeof(binary_bytes));
     TEST_ASSERT_EQUAL_INT64(0, Iron_websocket_send_bytes(
-        connected.socket, istrn(binary_bytes, sizeof(binary_bytes)), 5000));
+        connected.socket, outbound_binary, 5000));
+    iron_string_release(&outbound_binary);
     Iron_WebSocketMessage binary = Iron_websocket_receive(connected.socket, 5000);
     TEST_ASSERT_EQUAL_INT64(0, binary.error);
     TEST_ASSERT_EQUAL_INT64(IRON_WEBSOCKET_BINARY, binary.kind);
@@ -259,6 +309,11 @@ void test_websocket_client_server_text_binary_ping_close(void) {
     TEST_ASSERT_EQUAL_INT64(0, server.error);
     assert_bytes("hello websocket", 15, server.text);
     assert_bytes(binary_bytes, sizeof(binary_bytes), server.binary);
+    Iron_websocketmessage_release(text);
+    Iron_websocketmessage_release(binary);
+    Iron_websocketmessage_release(pong);
+    Iron_websocketresult_release(connected);
+    release_server_case(&server);
     Iron_httpserver_close(server.server);
 }
 
@@ -346,6 +401,7 @@ void test_websocket_fragmentation_with_interleaved_ping(void) {
     TEST_ASSERT_EQUAL_INT(0, thread_join(thread));
     TEST_ASSERT_EQUAL_INT64(0, server.error);
     assert_bytes("Hello", 5, server.text);
+    release_server_case(&server);
     Iron_tcpsocket_close(raw);
     Iron_httpserver_close(server.server);
 }
@@ -362,6 +418,7 @@ void test_websocket_rejects_unmasked_client_frame(void) {
     TEST_ASSERT_EQUAL_INT64(0, sent.v1.code);
     TEST_ASSERT_EQUAL_INT(0, thread_join(thread));
     TEST_ASSERT_EQUAL_INT64(IRON_ERR_WS_PROTOCOL, server.error);
+    release_server_case(&server);
     Iron_tcpsocket_close(raw);
     Iron_httpserver_close(server.server);
 }
@@ -376,6 +433,7 @@ void test_websocket_enforces_message_limit(void) {
     raw_send_masked(raw, 0x82, (const uint8_t *)"123456", 6, mask);
     TEST_ASSERT_EQUAL_INT(0, thread_join(thread));
     TEST_ASSERT_EQUAL_INT64(IRON_ERR_WS_MESSAGE_TOO_LARGE, server.error);
+    release_server_case(&server);
     Iron_tcpsocket_close(raw);
     Iron_httpserver_close(server.server);
 }
@@ -391,6 +449,7 @@ void test_websocket_rejects_invalid_utf8_text(void) {
     raw_send_masked(raw, 0x81, invalid, sizeof(invalid), mask);
     TEST_ASSERT_EQUAL_INT(0, thread_join(thread));
     TEST_ASSERT_EQUAL_INT64(IRON_ERR_WS_INVALID_UTF8, server.error);
+    release_server_case(&server);
     Iron_tcpsocket_close(raw);
     Iron_httpserver_close(server.server);
 }
@@ -400,6 +459,7 @@ void test_websocket_rejects_handshake_header_override(void) {
         istr("ws://127.0.0.1:1/"), istr("Sec-WebSocket-Key: attacker"),
         1024, 100);
     TEST_ASSERT_EQUAL_INT64(IRON_ERR_WS_INVALID_ARGUMENT, result.error);
+    Iron_websocketresult_release(result);
 }
 
 void test_websocket_negotiates_ordered_subprotocols(void) {
@@ -425,6 +485,8 @@ void test_websocket_negotiates_ordered_subprotocols(void) {
     TEST_ASSERT_EQUAL_INT64(0, server.error);
     TEST_ASSERT_EQUAL_STRING("graphql-transport-ws",
                              iron_string_cstr(&server.protocol));
+    Iron_websocketresult_release(connected);
+    release_server_case(&server);
     Iron_httpserver_close(server.server);
 }
 
@@ -443,6 +505,8 @@ void test_websocket_rejects_unoffered_server_protocol(void) {
     TEST_ASSERT_NOT_EQUAL(0, connected.error);
     TEST_ASSERT_EQUAL_INT(0, thread_join(thread));
     TEST_ASSERT_EQUAL_INT64(IRON_ERR_WS_HANDSHAKE, server.error);
+    Iron_websocketresult_release(connected);
+    release_server_case(&server);
     Iron_httpserver_close(server.server);
 }
 
@@ -452,12 +516,14 @@ void test_websocket_rejects_invalid_or_duplicate_protocols(void) {
     Iron_WebSocketResult bad = Iron_websocket_connect_with_protocols(
         istr("ws://127.0.0.1:1/"), istr(""), invalid, 1024, 100);
     TEST_ASSERT_EQUAL_INT64(IRON_ERR_WS_INVALID_ARGUMENT, bad.error);
+    Iron_websocketresult_release(bad);
 
     Iron_String duplicate_items[] = { istr("mqtt"), istr("mqtt") };
     Iron_List_Iron_String duplicate = { duplicate_items, 2, 2 };
     bad = Iron_websocket_connect_with_protocols(
         istr("ws://127.0.0.1:1/"), istr(""), duplicate, 1024, 100);
     TEST_ASSERT_EQUAL_INT64(IRON_ERR_WS_INVALID_ARGUMENT, bad.error);
+    Iron_websocketresult_release(bad);
 }
 
 void test_websocket_rejects_noncanonical_client_key(void) {
@@ -469,6 +535,7 @@ void test_websocket_rejects_noncanonical_client_key(void) {
         port, "dGhlIHNhbXBsZSBub25jZR==");
     TEST_ASSERT_EQUAL_INT(0, thread_join(thread));
     TEST_ASSERT_EQUAL_INT64(IRON_ERR_WS_HANDSHAKE, server.error);
+    release_server_case(&server);
     Iron_tcpsocket_close(raw);
     Iron_httpserver_close(server.server);
 }
@@ -499,6 +566,8 @@ void test_websocket_serializes_concurrent_writers(void) {
         connected.socket, 1000, istr("writers done"), 5000));
     TEST_ASSERT_EQUAL_INT(0, thread_join(server_thread));
     TEST_ASSERT_EQUAL_INT64(0, server.error);
+    Iron_websocketresult_release(connected);
+    release_server_case(&server);
     Iron_httpserver_close(server.server);
 }
 
@@ -518,13 +587,17 @@ void test_websocket_64_bit_length_binary_roundtrip(void) {
     TEST_ASSERT_EQUAL_INT64(0, connected.error);
     uint8_t medium[126];
     for (size_t i = 0; i < sizeof(medium); i++) medium[i] = (uint8_t)i;
+    Iron_String medium_out = istrn(medium, sizeof(medium));
     TEST_ASSERT_EQUAL_INT64(0, Iron_websocket_send_bytes(
-        connected.socket, istrn(medium, sizeof(medium)), 5000));
+        connected.socket, medium_out, 5000));
+    iron_string_release(&medium_out);
     Iron_WebSocketMessage medium_echo = Iron_websocket_receive(connected.socket, 5000);
     TEST_ASSERT_EQUAL_INT64(0, medium_echo.error);
     assert_bytes(medium, sizeof(medium), medium_echo.data);
+    Iron_String payload_out = istrn(payload, payload_length);
     TEST_ASSERT_EQUAL_INT64(0, Iron_websocket_send_bytes(
-        connected.socket, istrn(payload, payload_length), 5000));
+        connected.socket, payload_out, 5000));
+    iron_string_release(&payload_out);
     Iron_WebSocketMessage echoed = Iron_websocket_receive(connected.socket, 5000);
     TEST_ASSERT_EQUAL_INT64(0, echoed.error);
     TEST_ASSERT_EQUAL_INT64(IRON_WEBSOCKET_BINARY, echoed.kind);
@@ -534,6 +607,10 @@ void test_websocket_64_bit_length_binary_roundtrip(void) {
     TEST_ASSERT_EQUAL_INT(0, thread_join(thread));
     TEST_ASSERT_EQUAL_INT64(0, server.error);
     assert_bytes(payload, payload_length, server.binary);
+    Iron_websocketmessage_release(medium_echo);
+    Iron_websocketmessage_release(echoed);
+    Iron_websocketresult_release(connected);
+    release_server_case(&server);
     Iron_httpserver_close(server.server);
     free(payload);
 }

--- a/tools/containers/iron-lsp-build.Containerfile
+++ b/tools/containers/iron-lsp-build.Containerfile
@@ -3,7 +3,9 @@ FROM docker.io/library/debian:bookworm-slim
 # Canonical silvaserver.local validation image. Keep the Clang runtime package
 # matched to Debian bookworm's default Clang 14 so ASan/UBSan/TSan link probes
 # and instrumented executables use one coherent toolchain. libssl-dev provides
-# both OpenSSL headers and pkg-config metadata for HTTPS/WSS builds.
+# both OpenSSL headers and pkg-config metadata for HTTPS/WSS builds. The X11,
+# OpenGL, and ALSA development packages mirror Linux CI so the registered
+# compile-only Raylib manual suite also runs in this canonical image.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -12,8 +14,15 @@ RUN apt-get update \
         git \
         libc6-dev \
         libclang-rt-14-dev \
+        libasound2-dev \
+        libgl1-mesa-dev \
         libssl-dev \
         libstdc++-12-dev \
+        libx11-dev \
+        libxcursor-dev \
+        libxi-dev \
+        libxinerama-dev \
+        libxrandr-dev \
         lld \
         llvm \
         make \


### PR DESCRIPTION
## Summary

This follow-up makes the networking, WebSocket, TLS, and file-operation models from #100 explicit about ownership and clean under LeakSanitizer. It also resolves the three portability defects exposed by running the repository's entire registered sanitizer suite in the canonical `silvaserver.local` image.

The public networking behavior is unchanged: HTTP/HTTPS clients and servers, REST endpoints, served webpages, WS/WSS subprotocols, concurrency, deadlines, persistent connections, and exact text/binary file operations keep the APIs added in #100. This patch finishes their lifetime contract and validation story.

## Explicit ownership and release APIs

- Adds consuming release operations for `String` heap storage while keeping interned and small-string storage safe no-ops.
- Adds public release helpers for HTTP server/client results, requests, responses, connections, HTTPS admission/handshake results, WebSocket results/messages, and file result models.
- Documents low-level TLS structs that own no Iron strings and therefore require no model release helper.
- Makes HTTP response constructors clone caller-provided headers and bodies, so releasing a response cannot invalidate dynamic caller values.
- Fixes `io.read_lines` cleanup for the source buffer and a discarded trailing empty line.
- Uses an interned content-type literal for JSON POST requests instead of leaving a heap string behind.
- Updates C fixtures, Iron integration programs, and networking examples to release every owned result on success and failure paths.

## LeakSanitizer validation model

The integration tests invoke an instrumented `ironc` before running the generated program. The compiler intentionally keeps process-lifetime caches, which previously obscured application ownership failures. The test commands now disable leak detection only for that compiler subprocess; generated HTTP, WebSocket, TLS, and file programs inherit the outer strict LeakSanitizer environment.

Before this patch, representative runs reported:

- HTTP model: 41,850 bytes in 220 allocations
- WebSocket model: 199,002 bytes in 32 allocations
- TLS model: 1,827 bytes in 43 allocations
- Iron HTTP integration: 204,423 bytes in 1,865 allocations
- Iron WebSocket integration: 204,836 bytes in 1,912 allocations
- Iron file integration: 141,898 bytes in 1,223 allocations
- C I/O coverage: 13,974 bytes in 444 allocations

All focused runs are now clean with `detect_leaks=1`, `exitcode=23`, no suppressions, and fatal ASan/UBSan options.

## Practical documentation

- Extends `docs/networking.md` with the ownership rule for each client, server, request, response, connection, WebSocket message, and file result.
- Mirrors the same practical guidance on the public networking website, including copy-paste release patterns for success and error paths.
- Keeps the supported native HTTPS/WSS matrix explicit: Linux and macOS use the real OpenSSL backend; Windows users use WSL.

## Canonical validation portability

- Adds the same X11, OpenGL, and ALSA development packages used by Linux CI to the canonical remote image, allowing the registered Raylib manual compile suite to run there.
- Lowers the parser recursion ceiling from 1,000 to 256 after x86_64 Clang ASan proved capable of overflowing an 8 MB stack before the former guard. The new ceiling remains over 25 times the maximum integration-corpus depth and preserves the 100-level moderate-nesting acceptance case.
- Fixes the Linux parent-death race guard by comparing the parent PID before and after `prctl(PR_SET_PDEATHSIG)` instead of treating a healthy container PID 1 as an orphan.

## Validation

Run on `silvaserver.local` using the rebuilt canonical Debian/Clang 14/OpenSSL image:

- Full non-benchmark ASan/UBSan suite: **487/487 runnable tests passed**, 0 failed.
- Strict focused ASan + LeakSanitizer + UBSan gate: **9/9 passed**, leak detection enabled, no suppressions.
- Focused ThreadSanitizer networking/file/concurrency gate: **9/9 passed**, no race reports.
- Focused Release networking/file gate: **9/9 passed**.
- Original parser and parent-watcher failures: **20/20 repeated runs each passed** under fatal sanitizers.
- Raylib manual suite in the rebuilt canonical image: **1/1 passed**.
- Networking examples: **8/8** pass `ironc check` and native compilation under fatal UBSan.
- Website validator: **23 pages passed**; only the 10 explicitly allowlisted pre-existing Raylib duplicate-ID warnings remain.

The focused gates cover runtime strings and threads, HTTP/REST serving, HTTPS/TLS, WebSocket/WSS, concurrent clients, persistent connections, exact regular and binary file round trips, and C I/O models.

Closes #99
Closes #103
Closes #104
Closes #105

## CI reliability follow-up

- Replaces the Phase 7 audit’s `echo | grep -q` checks under `pipefail`; the old form could turn a successful lookup into SIGPIPE and falsely report a registered parity test as missing. The repaired audit passed **500/500** remote repetitions against the full CTest graph.
- Replaces the HTTP pool test’s fixed sleep and teardown-racy handler counter with a first-wave admission barrier. It now proves that four occupied client slots prevent a fifth request from entering before any slot is released.
- Repeated full HTTP unit suites after the barrier change: **50/50 Release**, **50/50 ASan/UBSan**, and **30/30 ThreadSanitizer** passed on `silvaserver.local`.

Closes #107
Closes #108

